### PR TITLE
QuizButton 컴포넌트를 구현합니다.

### DIFF
--- a/SoloDeveloperTraining/SoloDeveloperTraining/DesignSystem/Components/QuizButton.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/DesignSystem/Components/QuizButton.swift
@@ -51,13 +51,20 @@ struct QuizButton: View {
                 .frame(height: Constant.height)
                 .background(backgroundColor)
                 .cornerRadius(Constant.cornerRadius)
-                .opacity(isPressed ? Constant.Opacity.pressed : Constant.Opacity.unPressed)
+                .opacity(opacity)
                 .animation(.none, value: isSelected)
         }
         .buttonStyle(.pressable(isPressed: $isPressed))
     }
+}
 
-    private var backgroundColor: SwiftUI.Color {
+// MARK: - Helper
+private extension QuizButton {
+    var opacity: Double {
+        isPressed ? Constant.Opacity.pressed : Constant.Opacity.unPressed
+    }
+
+    var backgroundColor: SwiftUI.Color {
         isSelected ? Constant.Color.selectedBackground : Constant.Color.defaultBackground
     }
 }


### PR DESCRIPTION
## 연관된 이슈

- closed #67 

## 작업 내용 및 고민 내용

### QuizButton 컴포넌트 구현
- 버튼 인터페이스를 `LargeButton` 컴포넌트와 비슷하게 구현했습니다.
- 부모 View에서 `.disabled()` 모디파이어를 제출하여 비활성화가 가능합니다.

### 고민했던 부분

#### `isSelected`를 파라미터로 받는 방식
```swift
QuizButton(
    isSelected: selectedIndex == 0,
    title: "1. ..."
) {
    selectedIndex = 0
}
```
- 처음에는 `isSelected`와 `action`에서 동시에 선택 상태를 다루는 것이 중복되는 느낌이 들었습니다.
- 하지만 "4개 선지 중 1개만 선택" 로직을 구현하려면, 상위 View에서 단일 `selectedIndex`로 모든 버튼의 선택 상태를 제어하는 것이 가장 명확하다고 판단했습니다.
- 각 버튼은 "내가 선택됐는지" 확인(`isSelected`)하고, 클릭 시 "나를 선택해달라"고 요청(`action`)하는 구조입니다.

## 스크린샷

<img width="642" height="241" alt="image" src="https://github.com/user-attachments/assets/5ff20df0-1ce3-4e56-aa1f-91d15fedeee7" />

https://github.com/user-attachments/assets/8ce17fe3-5fdb-4304-996b-6d6e132b46ad


## 리뷰 요구사항

- ~~다른 `action`과 `text`를 받는 Button 컴포넌트들의 인터페이스와 일관성을 맞추는 작업이 필요할 수도 있을거 같습니다!~~
- 인터페이스는 `LargeButton`에 비슷하게 했습니다.