### PR TITLE
HousingCard 컴포넌트를 구현합니다.

### DIFF
--- a/SoloDeveloperTraining/SoloDeveloperTraining/DesignSystem/Components/HousingCard.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/DesignSystem/Components/HousingCard.swift
@@ -56,33 +56,36 @@ private struct HousingCardContent: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            // 상단 텍스트 영역
-            HStack(spacing: Constant.Padding.titleSpacing) {
-                Text(housing.displayTitle)
-                    .textStyle(.callout)
+            VStack(spacing: 0) {
+                // 상단 텍스트 영역
+                HStack(spacing: Constant.Padding.titleSpacing) {
+                    Text(housing.displayTitle)
+                        .textStyle(.callout)
 
-                Text("₩\(housing.cost.gold.formatted)")
-                    .textStyle(.caption2)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-            }
-            .padding(.horizontal, Constant.Padding.horizontal)
-            .padding(.top, Constant.Padding.top)
-
-            Text("초당 재화 획득량 \(housing.goldPerSecond)")
-                .textStyle(.label)
-                .frame(maxWidth: .infinity, alignment: .leading)
+                    Text("₩\(housing.cost.gold.formatted)")
+                        .textStyle(.caption2)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
                 .padding(.horizontal, Constant.Padding.horizontal)
-                .padding(.top, Constant.Padding.textSpacing)
+                .padding(.top, Constant.Padding.top)
 
-            // 이미지 영역
-            Image(housing.imageName)
-                .resizable()
-                .aspectRatio(contentMode: .fill)
-                .frame(width: Constant.cardWidth)
-                .frame(maxHeight: .infinity)
-                .clipped()
-                .padding(.top, Constant.Padding.imageTop)
-                .padding(.bottom, Constant.Padding.buttonTop)
+                Text("초당 재화 획득량 \(housing.goldPerSecond)")
+                    .textStyle(.label)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, Constant.Padding.horizontal)
+                    .padding(.top, Constant.Padding.textSpacing)
+
+                // 이미지 영역
+                Image(housing.imageName)
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .frame(width: Constant.cardWidth)
+                    .frame(maxHeight: .infinity)
+                    .clipped()
+                    .padding(.top, Constant.Padding.imageTop)
+                    .padding(.bottom, Constant.Padding.buttonTop)
+            }
+            .contentShape(Rectangle())
 
             // 버튼 영역
             LargeButton(


### PR DESCRIPTION
## 연관된 이슈

- closed #63 

## 작업 내용 및 고민 내용

### HousingCard 컴포넌트 구현

#### 주요 기능
- 카드 선택/해제 기능 (카드 탭 제스처)
- LargeButton 탭을 통한 장착 기능
  - 장착된 카드는 "장착중" 상태로 표시되며 버튼 비활성화
- 높이는 `.frame(maxHeight: .infinity)`로 설정하여 유연하게 대응
- 이미지는 `aspectRatio(contentMode: .fill)`로 카드 높이에 맞춰 확장

#### 인터페이스 변경

- 초기 설계의 문제점
  - 4가지 복합 상태(`normal`, `selected`, `equipped`, `equippedSelected`)를 컴포넌트가 관리
  - 상위 뷰에서 관리해야 할 상태 로직이 컴포넌트 내부에 존재
  - `@Binding`으로 컴포넌트가 상태를 직접 변경
- 변경 후
  - 컴포넌트는 표현만 담당: `isEquipped`, `isSelected` 프로퍼티로 상태 표시
  - 상위 뷰는 상태 관리 담당: 어떤 카드가 선택/장착됐는지 판단

```swift
// After
struct HousingCard: View {
    let housing: Housing
    let isEquipped: Bool         // 상위 뷰가 판단한 결과
    let isSelected: Bool         // 상위 뷰가 판단한 결과
    let onTap: () -> Void        // 선택 이벤트
    let onButtonTap: () -> Void  // 장착 이벤트
}
```

## 스크린샷

<img width="451" height="613" alt="image" src="https://github.com/user-attachments/assets/58955f4e-b91c-4d23-b6d0-b5fb962466b1" />

https://github.com/user-attachments/assets/c6b854fc-616b-4895-a7ef-61bc6d6dfd5b

```swift
#Preview {
    @Previewable @State var isSelected = false
    @Previewable @State var isEquipped = false

    HousingCard(
        housing: .villa,
        isEquipped: isEquipped,
        isSelected: isSelected,
        onTap: {
            isSelected.toggle()
        },
        onButtonTap: {
            isEquipped = true
        }
    )
    .frame(height: 500)
}
```

## 리뷰 요구사항

- 피그마와 다른 구현 사항
  - 피그마에서는 LargeButton의 width가 140으로 지정되어 있습니다.
  - 하지만 LargeButton 컴포넌트 자체에 width를 고정해서 사용하기로 했기 때문에, HousingCard에서는 별도의 width 지정 없이 사용했습니다.
- 인터페이스가 적절한지 봐주세요!