### PR TITLE
ItemRow 컴포넌트를 구현합니다.

### DIFF
--- a/SoloDeveloperTraining/SoloDeveloperTraining/DesignSystem/Components/ItemRow.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/DesignSystem/Components/ItemRow.swift
@@ -17,6 +17,11 @@ private enum Constant {
         static let horizontal: CGFloat = 8
         static let vertical: CGFloat = 4
     }
+
+    enum Padding {
+        static let horizontal: CGFloat = 16
+        static let vertical: CGFloat = 8
+    }
 }
 
 struct ItemRow: View {
@@ -53,6 +58,8 @@ struct ItemRow: View {
                 action: action
             )
         }
+        .padding(.horizontal, Constant.Padding.horizontal)
+        .padding(.vertical, Constant.Padding.vertical)
     }
 }
 
@@ -77,5 +84,4 @@ struct ItemRow: View {
             print("Tapped")
         }
     }
-    .padding(.horizontal)
 }

--- a/SoloDeveloperTraining/SoloDeveloperTraining/DesignSystem/Components/PriceButton.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/DesignSystem/Components/PriceButton.swift
@@ -10,7 +10,7 @@ import SwiftUI
 private enum Constant {
     enum Layout {
         static let cornerRadius: CGFloat = 5
-        static let buttonHeight: CGFloat = 44
+        static let buttonHeight: CGFloat = 38
         static let contentSpacing: CGFloat = 3
         static let horizontalPadding: CGFloat = 8
     }


### PR DESCRIPTION
## 연관된 이슈

- closed #68 

## 작업 내용 및 고민 내용

- 기존의 price Button이 Button으로 감싸져 있어서 frame 사용시 버튼의 크기가 변하지 않아서 width를 추가하였습니다.
- CareerRow의 vertical이 2에서 4로 변경되어 해당 Row도 4로 적용하였습니다.

- 인터페이스
```
        ItemRow(
            title: "강화 / 아이템 이름 이름 이름",
            description: "항목 설명 설명 설명",
            imageName: "background_street",
            price: 1_000_000,
            isDisabled: false
        ) {
            print("Tapped")
        }
```

## 스크린샷

<img width="418" height="127" alt="image" src="https://github.com/user-attachments/assets/33ba5846-08e5-41de-a8f5-22c325074784" />
