### PR TITLE
단위 정책을 적용합니다.

### DIFF
--- a/SoloDeveloperTraining/SoloDeveloperTraining/Extensions/Int+.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Extensions/Int+.swift
@@ -9,12 +9,37 @@ import Foundation
 
 extension Int {
     var formatted: String {
-        Self.decimalFormatter.string(from: NSNumber(value: self)) ?? "\(self)"
+        let absValue = abs(self)
+        let sign = self < 0 ? "-" : ""
+
+        switch absValue {
+        case 0..<1_000:
+            return "\(sign)\(absValue)"
+        case 1_000..<1_000_000:
+            let value = Double(absValue) / 1_000.0
+            return "\(sign)\(formatDecimal(value))K"
+        case 1_000_000..<1_000_000_000:
+            let value = Double(absValue) / 1_000_000.0
+            return "\(sign)\(formatDecimal(value))M"
+        default:
+            let value = Double(absValue) / 1_000_000_000.0
+            return "\(sign)\(formatDecimal(value))B"
+        }
     }
 
-    private static let decimalFormatter: NumberFormatter = {
-        let formatter = NumberFormatter()
-        formatter.numberStyle = .decimal
-        return formatter
-    }()
+    /// 소수점을 적절히 포맷팅합니다 (불필요한 0 제거)
+    private func formatDecimal(_ value: Double) -> String {
+        // 소수점 이하 2자리까지 표시
+        var formatted = String(format: "%.2f", value)
+
+        // 끝의 0 제거
+        while formatted.contains(".") && formatted.hasSuffix("0") {
+            formatted = String(formatted.dropLast())
+        }
+        if formatted.hasSuffix(".") {
+            formatted = String(formatted.dropLast())
+        }
+
+        return formatted
+    }
 }


### PR DESCRIPTION
## 연관된 이슈

- closed #128 

## 작업 내용 및 고민 내용


#### 1. `formatted` 프로퍼티 개선
기존의 천 단위 구분 형식(`NumberFormatter` 사용)에서 축약 형식(K, M, B)으로 변경했습니다.

**변경 전:**
```swift
var formatted: String {
    Self.decimalFormatter.string(from: NSNumber(value: self)) ?? "\(self)"
}

private static let decimalFormatter: NumberFormatter = {
    let formatter = NumberFormatter()
    formatter.numberStyle = .decimal
    return formatter
}()
```

**변경 후:**
```swift
var formatted: String {
    let absValue = abs(self)
    let sign = self < 0 ? "-" : ""
    
    switch absValue {
    case 0..<1_000:
        return "\(sign)\(absValue)"
    case 1_000..<1_000_000:
        let value = Double(absValue) / 1_000.0
        return "\(sign)\(formatDecimal(value))K"
    case 1_000_000..<1_000_000_000:
        let value = Double(absValue) / 1_000_000.0
        return "\(sign)\(formatDecimal(value))M"
    default:
        let value = Double(absValue) / 1_000_000_000.0
        return "\(sign)\(formatDecimal(value))B"
    }
}
```

#### 2. `formatDecimal` 메서드 추가
소수점을 적절히 포맷팅하고 불필요한 0을 제거하는 헬퍼 메서드를 추가했습니다.

```swift
/// 소수점을 적절히 포맷팅합니다 (불필요한 0 제거)
private func formatDecimal(_ value: Double) -> String {
    // 소수점 이하 2자리까지 표시 (자동 반올림)
    var formatted = String(format: "%.2f", value)

    // 끝의 0 제거
    while formatted.contains(".") && formatted.hasSuffix("0") {
        formatted = String(formatted.dropLast())
    }
    if formatted.hasSuffix(".") {
        formatted = String(formatted.dropLast())
    }

    return formatted
}
```

---

## 예상 결과

### 숫자 범위별 표시 형식

| 입력 값 | 표시 형식 | 설명 |
|---------|-----------|------|
| `0` | `"0"` | 1,000 미만은 그대로 표시 |
| `999` | `"999"` | 1,000 미만은 그대로 표시 |
| `1_000` | `"1K"` | 정수인 경우 소수점 없이 표시 |
| `1_050` | `"1.05K"` | 소수점 둘째 자리까지 표시 |
| `1_500` | `"1.5K"` | 끝의 0 제거 |
| `10_000` | `"10K"` | 정수인 경우 소수점 없이 표시 |
| `123_456` | `"123.46K"` | 반올림 처리 |
| `1_000_000` | `"1M"` | 1,000,000 이상은 M 형식 |
| `1_500_000` | `"1.5M"` | 소수점 표시 |
| `753_135_445` | `"753.14M"` | 소수점 둘째 자리까지 표시 |
| `1_000_000_000` | `"1B"` | 1,000,000,000 이상은 B 형식 |
| `7_531_354_454` | `"7.53B"` | 내림 처리 |
| `-1000` | `"-1K"` | 음수는 마이너스 기호 표시 |
| `-1500` | `"-1.5K"` | 음수도 소수점 처리 |
| `-1_000_000` | `"-1M"` | 음수 M 형식 |
| `-753_135_445` | `"-753.14M"` | 음수 소수점 표시 |
| `-7_531_354_454` | `"-7.53B"` | 음수 B 형식 |

### 포맷팅 로직 동작 예시

#### 예시 1: 1,050
- 1,000 이상이므로 K 형식
- 1,050 ÷ 1,000 = 1.05
- `formatDecimal(1.05)` → `"1.05"` (끝의 0이 없으므로 그대로)
- 결과: `"1.05K"`

#### 예시 2: 1,500
- 1,000 이상이므로 K 형식
- 1,500 ÷ 1,000 = 1.5
- `formatDecimal(1.5)` → `"1.5"` (끝의 0이 없으므로 그대로)
- 결과: `"1.5K"`

#### 예시 3: 1,000
- 1,000 이상이므로 K 형식
- 1,000 ÷ 1,000 = 1.0
- `formatDecimal(1.0)` → `"1.00"` → 끝의 0 제거 → `"1.0"` → 끝의 0 제거 → `"1."` → 끝의 `.` 제거 → `"1"`
- 결과: `"1K"`

#### 예시 4: 753,135,445
- 1,000,000 이상이므로 M 형식
- 753,135,445 ÷ 1,000,000 = 753.135445
- `formatDecimal(753.135445)` → `"753.14"` (반올림)
- 결과: `"753.14M"`

#### 예시 5: 7,531,354,454
- 1,000,000,000 이상이므로 B 형식
- 7,531,354,454 ÷ 1,000,000,000 = 7.531354454
- `formatDecimal(7.531354454)` → `"7.53"` (반올림)
- 결과: `"7.53B"`

#### 예시 6: -1,500
- 음수이므로 마이너스 기호 추가
- 절댓값 1,500은 1,000 이상이므로 K 형식
- 1,500 ÷ 1,000 = 1.5
- `formatDecimal(1.5)` → `"1.5"`
- 결과: `"-1.5K"`

#### 예시 7: -753,135,445
- 음수이므로 마이너스 기호 추가
- 절댓값 753,135,445는 1,000,000 이상이므로 M 형식
- 753,135,445 ÷ 1,000,000 = 753.135445
- `formatDecimal(753.135445)` → `"753.14"` (반올림)
- 결과: `"-753.14M"`

## 스크린샷

### 액션 적용 전

https://github.com/user-attachments/assets/5e29e53f-8c18-4975-9b50-346c71d47f0a

### 액션 적용 후

https://github.com/user-attachments/assets/de2760a1-537d-4336-80af-d8b455adc85b

## 리뷰 요구사항

- 포메팅이 잘 되되고 로직 작성이 적절한지.
- 획득한 골드(예를 들어 탭 게임에서)도 포메팅을 적용해야 하는지.