### PR TITLE
코드짜기 게임의 멀티 터치 기능 및 Bottom SafeArea를 준수하도록 변경합니다.

### DIFF
--- a/SoloDeveloperTraining/SoloDeveloperTraining.xcodeproj/project.pbxproj
+++ b/SoloDeveloperTraining/SoloDeveloperTraining.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 				Production/Presentation/LanguageGameView.swift,
 				Production/Presentation/MainView.swift,
 				Production/Presentation/MissionView.swift,
+				Production/Presentation/MultiTouchView.swift,
 				Production/Presentation/ShopView.swift,
 				Production/Presentation/StackGameScene.swift,
 				Production/Presentation/StackGameView.swift,

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/MultiTouchView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/MultiTouchView.swift
@@ -1,0 +1,51 @@
+//
+//  MultiTouchView.swift
+//  SoloDeveloperTraining
+//
+//  Created by 최범수 on 2026-01-23.
+//
+
+import SwiftUI
+import UIKit
+
+struct MultiTouchView: UIViewRepresentable {
+    let onTap: (CGPoint) -> Void
+
+    func makeUIView(context: Context) -> MultiTouchUIView {
+        let view = MultiTouchUIView()
+        view.onTap = onTap
+        return view
+    }
+
+    func updateUIView(_ uiView: MultiTouchUIView, context: Context) {
+        uiView.onTap = onTap
+    }
+}
+
+final class MultiTouchUIView: UIView {
+    var onTap: ((CGPoint) -> Void)?
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        isMultipleTouchEnabled = true
+        isUserInteractionEnabled = true
+        backgroundColor = .clear
+    }
+
+    required init?(coder: NSCoder) { nil }
+
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        super.touchesBegan(touches, with: event)
+
+        // 모든 터치에 대해 처리
+        for touch in touches {
+            let location = touch.location(in: self)
+            let safeAreaBottom = safeAreaInsets.bottom
+            let maxY = bounds.height - safeAreaBottom
+
+            if location.y <= maxY {
+                onTap?(location)
+            }
+        }
+    }
+}

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/TapGameView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/TapGameView.swift
@@ -42,12 +42,12 @@ struct TapGameView: View {
     }
 
     var body: some View {
-        GeometryReader { _ in
+        GeometryReader { geometry in
             VStack(spacing: 0) {
                 // 상단 툴바 (닫기, 아이템 버튼, 피버 게이지)
                 toolbarSection
                 // 터치 가능한 게임 영역
-                tapAreaSection
+                tapAreaSection(geometry: geometry)
             }
         }
     }
@@ -77,9 +77,14 @@ private extension TapGameView {
     }
 
     /// 터치 가능한 게임 영역
-    var tapAreaSection: some View {
+    func tapAreaSection(geometry: GeometryProxy) -> some View {
         ZStack {
-            Color.clear         // ZStack이 전체 영역을 차지하도록 함
+            // 배경 이미지
+            Image(.tapBackground)
+                .resizable()
+                .aspectRatio(contentMode: .fill)
+
+            // 효과 라벨들
             ForEach(effectLabels) { effectLabel in
                 EffectLabel(
                     value: effectLabel.value,
@@ -87,15 +92,11 @@ private extension TapGameView {
                 )
                 .position(effectLabel.position)
             }
-        }
-        .background(
-            Image(.tapBackground)
-                .resizable()
-                .aspectRatio(contentMode: .fill)
-        )
-        .contentShape(Rectangle())
-        .onTapGesture { location in
-            Task { await handleTap(at: location) }
+
+            // 멀티터치 뷰
+            MultiTouchView { location in
+                Task { await handleTap(at: location) }
+            }
         }
     }
 }


### PR DESCRIPTION
## 연관된 이슈

- closed #158 
- closed #164 

# 작업 내용

1. **멀티터치 지원**
   - 여러 손가락으로 동시에 탭할 수 있는 기능 추가
   - `isMultipleTouchEnabled = true` 설정으로 동시 터치 감지

2. **Safe Area 제한**
   - 바텀 safe area 안쪽으로만 터치가 처리되도록 제한
   - 홈 인디케이터 영역의 터치는 무시

## 구현 내용

### 1. MultiTouchView 구현

```swift
struct MultiTouchView: UIViewRepresentable {
    let onTap: (CGPoint) -> Void
    
    func makeUIView(context: Context) -> MultiTouchUIView {
        let view = MultiTouchUIView()
        view.onTap = onTap
        return view
    }
    
    func updateUIView(_ uiView: MultiTouchUIView, context: Context) {
        uiView.onTap = onTap
    }
}
```

### 2. MultiTouchUIView 구현

```swift
final class MultiTouchUIView: UIView {
    var onTap: ((CGPoint) -> Void)?
    
    override init(frame: CGRect) {
        super.init(frame: frame)
        isMultipleTouchEnabled = true
        isUserInteractionEnabled = true
        backgroundColor = .clear
    }
    
    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
        super.touchesBegan(touches, with: event)
        
        // 모든 터치에 대해 처리
        for touch in touches {
            let location = touch.location(in: self)
            let safeAreaBottom = safeAreaInsets.bottom
            let maxY = bounds.height - safeAreaBottom
            
            // Safe Area 안쪽인지 확인
            if location.y <= maxY {
                onTap?(location)
            }
        }
    }
}
```

## 스크린샷

## 리뷰 요구사항
