### PR TITLE
WorkSegmentControl를 개선합니다.

### DIFF
--- a/SoloDeveloperTraining/SoloDeveloperTraining/DesignSystem/Components/WorkSegmentControl.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/DesignSystem/Components/WorkSegmentControl.swift
@@ -13,7 +13,7 @@ private enum Constant {
 
 struct WorkSegmentControl: View {
     let items: [WorkItem]
-    @Binding var selectedIndex: Int?
+    @Binding var selectedIndex: Int
 
     var body: some View {
         HStack(spacing: Constant.itemSpacing) {
@@ -35,12 +35,7 @@ struct WorkSegmentControl: View {
 private extension WorkSegmentControl {
     func handleTap(at index: Int) {
         guard !items[index].isDisabled else { return }
-
-        if selectedIndex == index {
-            selectedIndex = nil
-        } else {
-            selectedIndex = index
-        }
+        selectedIndex = index
     }
 
     func buttonState(for index: Int) -> WorkItemButton.ButtonState {
@@ -74,10 +69,10 @@ struct WorkItem {
 }
 
 #Preview {
-    @Previewable @State var selectedIndex: Int? = 0
+    @Previewable @State var selectedIndex: Int = 0
 
     VStack(spacing: 20) {
-        Text("Selected Index: \(selectedIndex.map(String.init) ?? "None")")
+        Text("Selected Index: \(selectedIndex)")
             .textStyle(.headline)
 
         WorkSegmentControl(

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/WorkSelectedView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/WorkSelectedView.swift
@@ -13,6 +13,17 @@ private enum Constant {
         static let selectionViewBottom: CGFloat = 30
     }
 
+    enum UserDefaults {
+        static let lastSelectedWorkIndexKey = "lastSelectedWorkIndex"
+    }
+
+    enum Description {
+        static let tapGame = "모니터를 최대한 많이 누르세요."
+        static let languageGame = "올바른 버튼을 누르세요."
+        static let dodgeGame = "기기를 기울여 버그를 피하고 골드를 획득하세요."
+        static let stackGame = "최대한 높은 데이터를 쌓으세요."
+    }
+
     static let contentSpacing: CGFloat = 17
     static let descriptionSpacing: CGFloat = 10
 }
@@ -21,16 +32,22 @@ struct WorkSelectedView: View {
 
     let user: User
     let animationSystem: CharacterAnimationSystem?
-    @State var selectedIndex: Int?
+    @State var selectedIndex: Int = 0
     @State var isGameStarted: Bool = false
 
     var body: some View {
         Group {
-            if isGameStarted, let index = selectedIndex {
-                gameView(for: index)
+            if isGameStarted {
+                gameView(for: selectedIndex)
             } else {
                 selectionView
             }
+        }
+        .onAppear {
+            loadLastSelectedIndex()
+        }
+        .onChange(of: selectedIndex) { _, newValue in
+            saveLastSelectedIndex(newValue)
         }
     }
 }
@@ -56,13 +73,8 @@ private extension WorkSelectedView {
 
     var descriptionStack: some View {
         VStack(alignment: .leading, spacing: Constant.descriptionSpacing) {
-            Text("언어 맞추기 게임 스토리 설명")
-                .foregroundStyle(.black)
-                .textStyle(.subheadline)
-                .frame(maxWidth: .infinity, alignment: .leading)
-
-            Text("언어 맞추기 게임 액션 설명")
-                .foregroundStyle(.gray200)
+            Text(actionDescription(for: selectedIndex))
+                .foregroundStyle(.gray300)
                 .textStyle(.subheadline)
                 .frame(maxWidth: .infinity, alignment: .leading)
         }
@@ -74,7 +86,6 @@ private extension WorkSelectedView {
         }
         .frame(maxWidth: .infinity, alignment: .bottom)
         .padding(.bottom, Constant.Padding.selectionViewBottom)
-        .disabled(selectedIndex == nil)
     }
 }
 
@@ -99,10 +110,9 @@ private extension WorkSelectedView {
                 imageName: "housing_street"
             ),
             .init(
-                title: "물건 쌓기",
+                title: "데이터 쌓기",
                 description: "효과 설명",
-                imageName: "housing_street",
-                isDisabled: false
+                imageName: "housing_street"
             )
         ]
     }
@@ -121,6 +131,34 @@ private extension WorkSelectedView {
         default:
             EmptyView()
         }
+    }
+
+    func actionDescription(for index: Int) -> String {
+        switch index {
+        case 0:
+            return Constant.Description.tapGame
+        case 1:
+            return Constant.Description.languageGame
+        case 2:
+            return Constant.Description.dodgeGame
+        case 3:
+            return Constant.Description.stackGame
+        default:
+            return ""
+        }
+    }
+
+    func loadLastSelectedIndex() {
+        let savedIndex = UserDefaults.standard.integer(forKey: Constant.UserDefaults.lastSelectedWorkIndexKey)
+        if savedIndex >= 0 && savedIndex < workItems.count {
+            selectedIndex = savedIndex
+        } else {
+            selectedIndex = 0
+        }
+    }
+
+    func saveLastSelectedIndex(_ index: Int) {
+        UserDefaults.standard.set(index, forKey: Constant.UserDefaults.lastSelectedWorkIndexKey)
     }
 }
 


### PR DESCRIPTION
## 연관된 이슈

- closed #157 

## 작업 내용 및 고민 내용

### 1. UserDefault를 사용한 마지막 선택 기억 기능

**변경 내용**:
- `Constant.UserDefaults.lastSelectedWorkIndexKey` 상수 추가
- `loadLastSelectedIndex()` 함수 추가: 앱 실행 시 저장된 인덱스 로드
- `saveLastSelectedIndex(_:)` 함수 추가: 선택 변경 시 UserDefault에 저장
- 기본값: 0 (코드짜기)
- `onAppear`에서 로드, `onChange(of: selectedIndex)`에서 저장

### 2. SegmentControl 항상 하나 선택되도록 수정

**목적**: 사용자가 선택을 해제할 수 없도록 항상 하나의 항목이 선택된 상태 유지

**변경 전**:
```swift
@State var selectedIndex: Int?

func handleTap(at index: Int) {
    guard !items[index].isDisabled else { return }
    if selectedIndex == index {
        selectedIndex = nil  // 선택 해제 가능
    } else {
        selectedIndex = index
    }
}
```

**변경 후**:
```swift
@State var selectedIndex: Int = 0

func handleTap(at index: Int) {
    guard !items[index].isDisabled else { return }
    selectedIndex = index  // 항상 선택 유지
}
```

### 3. 기타 수정 사항

게임 제목 변경
- "물건 쌓기" → "데이터 쌓기"

UI 스타일 조정
- 액션 설명 텍스트 색상: `.gray200` → `.gray300`

## 스크린샷


https://github.com/user-attachments/assets/e2089d97-52aa-4270-b0f7-47114a961016



## 리뷰 요구사항
