### PR TITLE
데이터 쌓기 게임 내 피버 게이지 동작을 정상화합니다.

### DIFF
--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/StackGameView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/StackGameView.swift
@@ -19,26 +19,25 @@ private enum Constant {
 }
 
 struct StackGameView: View {
-    let stackGame: StackGame
+    @State private var stackGame: StackGame
     @State private var scene: StackGameScene
-    @State private var feverSystem: FeverSystem
+    @State private var effectLabels: [EffectLabelData] = []
+
     /// 게임 시작 상태 (부모 뷰와 바인딩)
     @Binding var isGameStarted: Bool
-
-    @State private var effectLabels: [EffectLabelData] = []
 
     init(
         user: User,
         isGameStarted: Binding<Bool>,
         animationSystem: CharacterAnimationSystem? = nil
     ) {
-        self.stackGame = StackGame(user: user, animationSystem: animationSystem)
-        self._feverSystem = State(wrappedValue: stackGame.feverSystem)
-        self._isGameStarted = isGameStarted
+        let stackGame = StackGame(user: user, animationSystem: animationSystem)
         let initialScene = StackGameScene(
             stackGame: stackGame,
             onBlockDropped: { _ in }
         )
+        self._isGameStarted = isGameStarted
+        self._stackGame = State(initialValue: stackGame)
         self._scene = State(initialValue: initialScene)
     }
 
@@ -67,7 +66,7 @@ private extension StackGameView {
             closeButtonDidTapHandler: handleCloseButton,
             coffeeButtonDidTapHandler: { useConsumableItem(.coffee) },
             energyDrinkButtonDidTapHandler: { useConsumableItem(.energyDrink) },
-            feverState: feverSystem,
+            feverState: stackGame.feverSystem,
             buffSystem: stackGame.buffSystem,
             coffeeCount: .constant(stackGame.user.inventory.count(.coffee) ?? 0),
             energyDrinkCount: .constant(stackGame.user.inventory.count(.energyDrink) ?? 0)


### PR DESCRIPTION
## 연관된 이슈

- closed #216 

## 작업 내용 및 고민 내용

Swift UI 뷰 랜더링: State변경 감지 -> 뷰 바디 리랜더링

문제 원인:
GameTabBar가 변경을 감지하지 못함.

해결: 
이미 FeverSystem은 Observable함.
-> 뷰 내부 State 선언 후, 참조를 가져옴.
-> 가져온 State 참조를 GameTabBar에 전달

## 스크린샷

https://github.com/user-attachments/assets/ff6c83f9-0d40-43f2-9015-412f5b328a1f

## 리뷰 요구사항
- 다른 게임들은 문제가 없는 이유를 모르겠네요...?