### PR TITLE
Github Action을 통한 릴리즈 노트 자동화를 설정합니다.

### DIFF
--- a/.github/workflows/release-note.yml
+++ b/.github/workflows/release-note.yml
@@ -24,11 +24,12 @@ jobs:
       - name: Extract Xcode version info
         id: xcode_version
         run: |
+          PROJECT_NAME="SoloDeveloperTraining"  # 프로젝트 이름
           # project.pbxproj에서 MARKETING_VERSION 추출 (예: 1.0.0)
-          MARKETING_VERSION=$(grep -m 1 "MARKETING_VERSION = " *.xcodeproj/project.pbxproj | sed 's/.*MARKETING_VERSION = \(.*\);/\1/' | tr -d ' ')
-          
+          MARKETING_VERSION=$(grep -m 1 "MARKETING_VERSION = " "${PROJECT_NAME}/${PROJECT_NAME}.xcodeproj/project.pbxproj" | sed 's/.*MARKETING_VERSION = \(.*\);/\1/' | tr -d ' ')
+
           # project.pbxproj에서 CURRENT_PROJECT_VERSION 추출 (빌드 번호, 예: 42)
-          BUILD_NUMBER=$(grep -m 1 "CURRENT_PROJECT_VERSION = " *.xcodeproj/project.pbxproj | sed 's/.*CURRENT_PROJECT_VERSION = \(.*\);/\1/' | tr -d ' ')
+          BUILD_NUMBER=$(grep -m 1 "CURRENT_PROJECT_VERSION = " "${PROJECT_NAME}/${PROJECT_NAME}.xcodeproj/project.pbxproj" | sed 's/.*MARKETING_VERSION = \(.*\);/\1/' | tr -d ' ')
           
           echo "marketing_version=$MARKETING_VERSION" >> $GITHUB_OUTPUT
           echo "build_number=$BUILD_NUMBER" >> $GITHUB_OUTPUT
@@ -166,7 +167,7 @@ jobs:
                 tag_name: tagName,
                 name: `v${marketingVersion}`,
                 body: fullReleaseNotes,
-                draft: true,
+                draft: false,
                 prerelease: false
               });
               console.log(`✅ Created draft release: ${tagName} (Build: ${buildNumber})`);


### PR DESCRIPTION
## 연관된 이슈

- closed #227

## 작업 내용 및 고민 내용
- 릴리즈 노트이기에 'Release, Someday' Label은 카테고라이징 대상에서 제외하였습니다.
- Xcode에서 설정한 버전을 단일 진실 원천으로 두기 위해 커스텀 워크플로우를 작성하였습니다.
- 큰 흐름은 아래와 같습니다.
```
PR이 main에 merge됨
    ↓
Xcode 버전 정보 추출 (마케팅 버전, 빌드 번호)
    ↓
해당 버전의 Git 태그가 이미 존재하는지 확인
    ↓
    ├─ 태그 존재 ✅ → 워크플로우 종료 (중복 방지)
    └─ 태그 없음 ❌ → 계속 진행
              ↓
         마지막 릴리즈 이후 merge된 PR 목록 가져오기
              ↓
         PR을 라벨별로 분류 (Feature, Bug, Maintenance, Others)
              ↓
         릴리즈 노트 텍스트 생성
              ↓
         릴리즈 노트 퍼블리싱
```

## 리뷰 요구사항
- PR label 별 카테고라이징이 적절한지 검토 부탁드립니다.
- 로직적인 오류가 없는지 검토 부탁드립니다.