### PR TITLE
인트로뷰에서 메인화면 전환 시 애니메이션 속도를 조정합니다.

### DIFF
--- a/SoloDeveloperTraining/SoloDeveloperTraining/App/SoloDeveloperTrainingApp.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/App/SoloDeveloperTrainingApp.swift
@@ -9,7 +9,8 @@ import SwiftUI
 
 private enum Constant {
     enum Animation {
-        static let duration: Double = 1.0
+        static let transitionDuration: Double = 0.5  // 화면 전환
+        static let blinkingDuration: Double = 1.0    // 깜빡임
     }
 
     enum Padding {
@@ -53,7 +54,7 @@ struct SoloDeveloperTrainingApp: App {
                     )
                 }
             }
-            .animation(.easeOut(duration: Constant.Animation.duration), value: hasSeenIntro)
+            .animation(.easeOut(duration: Constant.Animation.transitionDuration), value: hasSeenIntro)
             .overlay {
                 nicknameSetupOverlay
             }
@@ -68,7 +69,7 @@ struct SoloDeveloperTrainingApp: App {
                 }
                 .onAppear {
                     Task {
-                        try? await Task.sleep(nanoseconds: UInt64(Constant.Animation.duration * 1_000_000_000))
+                        try? await Task.sleep(nanoseconds: UInt64(Constant.Animation.transitionDuration * 1_000_000_000))
                         hasSeenIntro = true
                     }
                 }
@@ -132,7 +133,7 @@ private extension SoloDeveloperTrainingApp {
                     onStart: { nickname in
                         user = User(nickname: nickname)
                         showNicknameSetup = false
-                        withAnimation(.easeOut(duration: Constant.Animation.duration)) {
+                        withAnimation(.easeOut(duration: Constant.Animation.transitionDuration)) {
                             hasSeenIntro = true
                         }
                     },

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Intro/IntroView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Intro/IntroView.swift
@@ -9,7 +9,8 @@ import SwiftUI
 
 private enum Constant {
     enum Animation {
-        static let duration: Double = 1.0
+        static let transitionDuration: Double = 0.5  // 화면 전환
+        static let blinkingDuration: Double = 1.0    // 깜빡임
     }
 
     enum Layout {
@@ -41,7 +42,7 @@ struct IntroView: View {
             if user == nil {
                 showNicknameSetup = true
             } else {
-                withAnimation(.easeOut(duration: Constant.Animation.duration)) {
+                withAnimation(.easeOut(duration: Constant.Animation.transitionDuration)) {
                     hasSeenIntro = true
                 }
             }
@@ -72,7 +73,7 @@ private extension IntroView {
                 .textStyle(.title2)
                 .foregroundColor(.white)
                 .opacity(isBlinking ? Constant.Opacity.blinking : Constant.Opacity.normal)
-                .animation(.easeInOut(duration: Constant.Animation.duration).repeatForever(autoreverses: true), value: isBlinking)
+                .animation(.easeInOut(duration: Constant.Animation.blinkingDuration).repeatForever(autoreverses: true), value: isBlinking)
                 .padding(.bottom, Constant.Layout.bottomPadding)
         }
     }


### PR DESCRIPTION
## 연관된 이슈

- closed #179 

## 작업 내용 및 고민 내용

### 메인화면으로의 애니메이션 속도 1 -> 0.5
- 기존 메인화면으로 전환 시에 애니메이션 속도는 1.0 이었습니다.
- 원래는 삭제를 하려했으나 다음과 같은 문제가 있었습니다.
  - 바로 보이면서 캐릭터 노드가 로딩?이 되는 것이 시각적으로 보임
- 그래서 기존 속도의 절반인 0.5로 조정하기로 변경을 결정했습니다.
  - 화면 전환 속도는 0.5
  - 인트로뷰의 텍스트 blink 속도는 기존 속도의 1.0을 유지했습니다.
- 아래는 캐릭터 노드가 로드되는 문제 장면입니다.

https://github.com/user-attachments/assets/133cff34-0304-4c85-8d3c-03d0895d39f7

## 스크린샷

https://github.com/user-attachments/assets/81e798c5-5f23-4caa-a2bb-be724cca16ea

https://github.com/user-attachments/assets/aa81d2c0-908a-4d35-8997-84abbc0da20d

## 리뷰 요구사항
- 전환 애니메이션이 적절한지 봐주세요!