### PR TITLE
릴리즈 노트 자동화 워크플로우를 수정합니다.

### DIFF
--- a/.github/workflows/release-note.yml
+++ b/.github/workflows/release-note.yml
@@ -94,10 +94,8 @@ jobs:
                 });
               }
 
-              // 3. 만약 하위 PR이 없다면 (단일 커밋 머지 등), 현재 PR이라도 포함시킵니다.
-              if (prNumbers.size === 0) {
-                prNumbers.add(pull_number);
-              }
+              // 3. 현재 PR을 포함시킵니다.
+              prNumbers.add(pull_number);
 
               console.log(`✅ Found ${prNumbers.size} unique sub-PRs.`);
 


### PR DESCRIPTION
## 연관된 이슈

- closed #243

## 작업 내용 및 고민 내용
- 빌드 넘버 파싱 로직 오류 해결
  - 기존 코드에서 마케팅 버전을 가져오고 있어서, 올바르게 수정했습니다.


* PR 파싱 로직 개선 (릴리즈 노트 누락 문제 해결)

  * 기존 로직은 `base:main` 조건으로 **main 브랜치에 직접 머지된 PR만 조회**하는 방식이었기 때문에,
    `feature → dev → main`과 같이 dev 브랜치를 경유해 병합된 개별 개발 PR들이 릴리즈 노트에서 누락되는 문제가 있었습니다.
  * 단순히 검색 조건의 `base`를 `dev`로 변경하는 방식도 검토했으나,
    이 경우 실제로 main에 반영되지 않은 PR까지 포함되거나, dev와 main 사이의 머지 시점·상태 불일치로 인해 릴리즈 노트와 실제 배포 내용 간 정합성이 깨질 수 있다는 문제가 있었습니다.
  * 이에 따라, **main에 머지된 최종 PR에 포함된 커밋 목록을 기준으로**, 각 커밋과 연관된 PR을 GitHub API를 통해 역추적하는 방식으로 로직을 변경했습니다.
  * 이를 통해 실제 main 브랜치에 반영된 변경 사항만을 기반으로 릴리즈 노트가 생성되도록 보장했습니다.
  * 또한 스크립트 실행 과정을 파악할 수 있도록 적절한 로그를 추가했습니다.

## 리뷰 요구사항
- 로직에 오류가 없는지