### PR TITLE
언어 맞추기 게임에서 크래시 방지 코드를 추가합니다.

### DIFF
--- a/SoloDeveloperTraining/SoloDeveloperTraining/GameCore/Models/Games/LanguageGame.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/GameCore/Models/Games/LanguageGame.swift
@@ -86,6 +86,9 @@ final class LanguageGame: Game {
 
     func startGame() {
         feverSystem.start()
+        if itemList.isEmpty {
+            itemList = makeInitialItemList()
+        }
     }
 
     func stopGame() {
@@ -107,10 +110,17 @@ final class LanguageGame: Game {
     }
 
     func didPerformAction(_ input: LanguageType) async -> Int {
+        // Task가 취소되었으면 즉시 종료
+        guard !Task.isCancelled else { return 0 }
+
         // 게임 종료 후 버튼 탭 크래시 방지
         guard itemList.count > leadingAndTrailingItemCount else { return 0 }
 
         let isSuccess = languageButtonTapHandler(tappedItemType: input)
+
+        // 비즈니스 로직 실행 전 다시 한 번 취소 확인
+        guard !Task.isCancelled else { return 0 }
+
         feverSystem
             .gainFever(
                 isSuccess ? Policy.Fever.Language.gainPerCorrect : Policy.Fever.Language.lossPerIncorrect


### PR DESCRIPTION
## 연관된 이슈

- closed #255 

## 작업 내용 및 고민 내용

### 문제 발생
<img width="1236" height="854" alt="image" src="https://github.com/user-attachments/assets/76e99910-bc39-41ab-b48b-157aa6b46a6c" />

- `LanguageGame`에서 간헐적으로 `Index out of range` 크래시 발생

### 원인 파악 (크래시 시나리오)

https://github.com/user-attachments/assets/708f0ba4-4a29-435c-a228-aa5ead1ed724

#### 1. 사용자가 언어 버튼 탭
- `handleLanguageButtonTap()` 호출
- `Task { await game.didPerformAction(LanguageType) }` 비동기 실행 시작

#### 2. 사용자가 빠르게 닫기 버튼 탭
- `handleCloseButton()` 호출
- `game.stopGame()` 실행 -> `itemList = []` (빈 배열로 초기화)

#### 3. 비동기 Task가 계속 실행됨
- `didPerformAction()`이 `languageButtonTapHandler()` 호출
- `itemList[leadingAndTrailingItemCount]` 접근 시도
- **빈 배열에 인덱스 접근 -> 크래시 발생**

### 문제 해결
- `didPerformAction()` 시작 시 `itemList` 크기 검증 추가
  - `guard itemList.count > leadingAndTrailingItemCount else { return 0 }`
- 게임 종료 상태에서는 조용히 `0`을 반환해서 부작용 방지
  - 크래시 방지, 골드 감소 없음

## 리뷰 요구사항
- 해결 방법이 적절한지 검토 부탁드립니다!
