### PR TITLE
아이템 구매 버튼 중복 클릭 오류를 해결합니다.

### DIFF
--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/ShopPurchaseHelper.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/ShopPurchaseHelper.swift
@@ -29,6 +29,8 @@ enum ShopPurchaseHelper {
         confirmTitle: String,
         onConfirm: @escaping () -> Void
     ) {
+        var didPurchasingButtonTapped = false
+
         popupContent.wrappedValue = PopupConfiguration(
             title: title,
             maxHeight: nil
@@ -44,8 +46,10 @@ enum ShopPurchaseHelper {
                         popupContent.wrappedValue = nil
                     }
                     MediumButton(title: confirmTitle, isFilled: true) {
-                        popupContent.wrappedValue = nil
+                        guard !didPurchasingButtonTapped else { return }
+                        didPurchasingButtonTapped = true
                         onConfirm()
+                        popupContent.wrappedValue = nil
                     }
                 }
             }

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/ShopView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/ShopView.swift
@@ -42,6 +42,7 @@ struct ShopView: View {
 
     @State private var selectedCategoryIndex: Int = 0
     @State private var selectedHousingTier: HousingTier?
+
     @Binding var popupContent: PopupConfiguration?
 
     init(user: User, popupContent: Binding<PopupConfiguration?>) {


### PR DESCRIPTION
## 연관된 이슈

- closed #256

## 작업 내용 및 고민 내용
### 중복 클릭 방지 로직 추가
- 현재 문제는 **팝업이 한 번 뜬 상태에서 팝업이 내려 가기 전에 "구매" 버튼을 여러 번 빠르게 누를 경우, 그 수만큼 구매가 된다는 점**입니다.
- 이를 문제로 정의했으므로 해결 후 목표 상태는 "**팝업이 한 번 뜬 상태에서는 한 번만 구매가 가능한 상태**" 로 정의했습니다.

- 팝업을 띄워주고 구매 로직 실행을 포함하고 있는 `ShopPurchaseHelper`의 `showConfirm` 메서드에, 구매 버튼 중복 클릭을 방지할 수 있는 플래그를 추가하였습니다.


### UITest / UnitTest 적합성
**- 결론적으로 테스트 코드는 따로 작성하지 않았습니다.**
- UITest를 도입하지 않은 이유: 시도하였으나, 앱 런치스크린 부터 상점 팝업의 구매 버튼에 도달하기 까지 계층적으로 `accessablilityIdentifier`를 일일이 지정하여 접근해야하는 번거로움이 있었습니다. 또한 혀재 해결책으로 `팝업이 열림 -> 구매 버튼 -> 팝업 닫힘`을 원자적인 액션으로 처리하고 있기 때문에 UITest로서 여러번 탭을 수행하는 코드를 추가한다면, 의도와 다른 테스트 실패로 처리되어 현 상황과 맞지 않다고 생각했습니다.
```
// 테스트 실패 시나리오
purchasingButton.tap()
purchasingButton.tap()  // 이미 팝업이 닫혀서 버튼을 누를 수 없음. ->  테스트 실패
```
- UnitTest를 도입하지 않은 이유: UnitTest를 진행한다면 구매 로직을 담당하는 ShopSystem에 대한 테스트가 이루어져야한다고 생각했습니다. 그러나 현재 상황은 UI단에서 중복 클릭을 막는 방법으로 해결가능하므로 해당 sut 단위 테스트와는 거리가 멀다고 생각했습니다.

## 스크린샷

https://github.com/user-attachments/assets/3632d777-a9a8-481d-bcee-7e5aff1fdc37
