### PR TITLE
미션 업데이트 로직을 비동기 처리로 변경합니다.

### DIFF
--- a/SoloDeveloperTraining/SoloDeveloperTraining/GameCore/Models/Games/LanguageGame.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/GameCore/Models/Games/LanguageGame.swift
@@ -109,25 +109,7 @@ final class LanguageGame: Game {
         buffSystem.resume()
     }
 
-    // ===== 📊 측정용 static 변수 =====
-    #if DEBUG
-    private static var callCount = 0
-    #endif
-
     func didPerformAction(_ input: LanguageType) async -> Int {
-        // ===== 📊 측정 코드 시작 =====
-        #if DEBUG
-        Self.callCount += 1
-        let currentCall = Self.callCount
-        let startTime = CFAbsoluteTimeGetCurrent()
-        var recordTime: Double = 0
-        defer {
-            let totalElapsed = (CFAbsoluteTimeGetCurrent() - startTime) * 1000
-            print("⏱️ [BEFORE #\(currentCall)] Total: \(String(format: "%.2f", totalElapsed))ms | Record: \(String(format: "%.2f", recordTime))ms")
-        }
-        #endif
-        // ===== 📊 측정 코드 끝 =====
-
         // Task가 취소되었으면 즉시 종료
         guard !Task.isCancelled else { return 0 }
 
@@ -152,20 +134,10 @@ final class LanguageGame: Game {
         if isSuccess {
             user.wallet.addGold(gainGold)
 
-            // ===== 📊 Record 시간 측정 시작 =====
-            #if DEBUG
-            let recordStart = CFAbsoluteTimeGetCurrent()
-            #endif
-
             /// 정답 횟수 기록
             user.record.record(.languageCorrect)
             /// 누적 재산 업데이트
             user.record.record(.earnMoney(gainGold))
-
-            #if DEBUG
-            recordTime = (CFAbsoluteTimeGetCurrent() - recordStart) * 1000
-            #endif
-            // ===== 📊 Record 시간 측정 끝 =====
 
             // 재화 획득 시 캐릭터 웃게 만들기
             animationSystem?.playSmile()
@@ -173,18 +145,8 @@ final class LanguageGame: Game {
         }
         user.wallet.spendGold(Int(Double(gainGold) * Policy.Game.Language.incorrectGoldLossMultiplier))
 
-        // ===== 📊 Record 시간 측정 시작 (오답 케이스) =====
-        #if DEBUG
-        let recordStart = CFAbsoluteTimeGetCurrent()
-        #endif
-
         /// 오답 횟수 기록
         user.record.record(.languageIncorrect)
-
-        #if DEBUG
-        recordTime = (CFAbsoluteTimeGetCurrent() - recordStart) * 1000
-        #endif
-        // ===== 📊 Record 시간 측정 끝 =====
 
         return Int(Double(gainGold) * Policy.Game.Language.incorrectGoldLossMultiplier) * -1
     }

--- a/SoloDeveloperTraining/SoloDeveloperTraining/GameCore/Models/Games/LanguageGame.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/GameCore/Models/Games/LanguageGame.swift
@@ -109,7 +109,25 @@ final class LanguageGame: Game {
         buffSystem.resume()
     }
 
+    // ===== 📊 측정용 static 변수 =====
+    #if DEBUG
+    private static var callCount = 0
+    #endif
+
     func didPerformAction(_ input: LanguageType) async -> Int {
+        // ===== 📊 측정 코드 시작 =====
+        #if DEBUG
+        Self.callCount += 1
+        let currentCall = Self.callCount
+        let startTime = CFAbsoluteTimeGetCurrent()
+        var recordTime: Double = 0
+        defer {
+            let totalElapsed = (CFAbsoluteTimeGetCurrent() - startTime) * 1000
+            print("⏱️ [BEFORE #\(currentCall)] Total: \(String(format: "%.2f", totalElapsed))ms | Record: \(String(format: "%.2f", recordTime))ms")
+        }
+        #endif
+        // ===== 📊 측정 코드 끝 =====
+
         // Task가 취소되었으면 즉시 종료
         guard !Task.isCancelled else { return 0 }
 
@@ -133,17 +151,41 @@ final class LanguageGame: Game {
         )
         if isSuccess {
             user.wallet.addGold(gainGold)
+
+            // ===== 📊 Record 시간 측정 시작 =====
+            #if DEBUG
+            let recordStart = CFAbsoluteTimeGetCurrent()
+            #endif
+
             /// 정답 횟수 기록
             user.record.record(.languageCorrect)
             /// 누적 재산 업데이트
             user.record.record(.earnMoney(gainGold))
+
+            #if DEBUG
+            recordTime = (CFAbsoluteTimeGetCurrent() - recordStart) * 1000
+            #endif
+            // ===== 📊 Record 시간 측정 끝 =====
+
             // 재화 획득 시 캐릭터 웃게 만들기
             animationSystem?.playSmile()
             return gainGold
         }
         user.wallet.spendGold(Int(Double(gainGold) * Policy.Game.Language.incorrectGoldLossMultiplier))
+
+        // ===== 📊 Record 시간 측정 시작 (오답 케이스) =====
+        #if DEBUG
+        let recordStart = CFAbsoluteTimeGetCurrent()
+        #endif
+
         /// 오답 횟수 기록
         user.record.record(.languageIncorrect)
+
+        #if DEBUG
+        recordTime = (CFAbsoluteTimeGetCurrent() - recordStart) * 1000
+        #endif
+        // ===== 📊 Record 시간 측정 끝 =====
+
         return Int(Double(gainGold) * Policy.Game.Language.incorrectGoldLossMultiplier) * -1
     }
 

--- a/SoloDeveloperTraining/SoloDeveloperTraining/GameCore/Models/Systems/MissionSystem.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/GameCore/Models/Systems/MissionSystem.swift
@@ -29,13 +29,13 @@ final class MissionSystem {
     }
 
     /// 기록을 통하여 현재 미션의 상태들을 업데이트 합니다.
+    /// - Note: 비동기로 처리되어 즉시 반환
+    /// - Parameter record: 업데이트할 Record
     func updateCompletedMissions(record: Record) {
-        missions
-            .filter { $0.state == .inProgress }
-            .forEach { $0.update(record: record) }
-
-        sortMissions()
-        checkHasCompletedMission()
+        // 메인 큐에 비동기로 추가 (즉시 반환, 순서 보장, 누락 없음)
+        DispatchQueue.main.async { [weak self] in
+            self?.performMissionUpdate(record: record)
+        }
     }
 
     func claimMissionReward(mission: Mission, wallet: Wallet) {
@@ -46,12 +46,25 @@ final class MissionSystem {
         sortMissions()
         checkHasCompletedMission()
     }
+}
 
-    private func checkHasCompletedMission() {
+// MARK: - Helper
+private extension MissionSystem {
+    /// 실제 미션 업데이트 수행 (메인 스레드, 비동기)
+    func performMissionUpdate(record: Record) {
+        missions
+            .filter { $0.state == .inProgress }
+            .forEach { $0.update(record: record) }
+
+        sortMissions()
+        checkHasCompletedMission()
+    }
+
+    func checkHasCompletedMission() {
         hasCompletedMission = missions.contains { $0.state == .claimable }
     }
 
-    private func sortMissions() {
+    func sortMissions() {
         missions.sort { $0.state.rawValue < $1.state.rawValue }
     }
 }

--- a/SoloDeveloperTraining/SoloDeveloperTrainingTests/MissionSystemTests.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTrainingTests/MissionSystemTests.swift
@@ -1,0 +1,130 @@
+//
+//  MissionSystemTests.swift
+//  SoloDeveloperTraining
+//
+//  Created by 김성훈 on 2/4/26.
+//
+
+import Testing
+import Foundation
+@testable import SoloDeveloperTraining
+
+@MainActor
+struct MissionSystemTests {
+
+    @Test("기본 미션 업데이트 동작 검증")
+    func testBasicMissionUpdate() async throws {
+        // Given: 목표 10인 언어 미션 생성
+        let mission = Mission(
+            id: 1,
+            type: .languageMatch(.bronze),
+            title: "언어 10회 성공",
+            description: "언어 게임 10회 성공하기",
+            targetValue: 10,
+            updateCondition: { $0.languageCorrectCount },
+            reward: Cost(gold: 100)
+        )
+        let missionSystem = MissionSystem(missions: [mission])
+        let record = Record(missionSystem: missionSystem)
+
+        // When: 10번 정답 기록
+        for _ in 1...10 {
+            record.record(.languageCorrect)
+        }
+
+        // 비동기 처리 완료 대기
+        try await Task.sleep(nanoseconds: 100_000_000) // 0.1초
+
+        // Then: 미션 완료되어야 함
+        #expect(mission.currentValue == 10, "미션 값이 10이어야 함")
+        #expect(mission.state == .claimable, "미션이 완료 상태여야 함")
+        #expect(missionSystem.hasCompletedMission == true, "완료된 미션이 있어야 함")
+    }
+
+    @Test("연속 업데이트 시 누락 방지 - 100회 연속 기록")
+    func testConsecutiveUpdateGuarantee() async throws {
+        // Given: 목표 100인 언어 미션
+        let mission = Mission(
+            id: 2,
+            type: .languageMatch(.silver),
+            title: "언어 100회 성공",
+            description: "언어 게임 100회 성공하기",
+            targetValue: 100,
+            updateCondition: { $0.languageCorrectCount },
+            reward: Cost(gold: 1000)
+        )
+        let missionSystem = MissionSystem(missions: [mission])
+        let record = Record(missionSystem: missionSystem)
+
+        // When: 100번 빠르게 연속 기록
+        for _ in 1...100 {
+            record.record(.languageCorrect)
+        }
+
+        // 비동기 처리 완료 대기
+        try await Task.sleep(nanoseconds: 100_000_000) // 0.1초
+
+        // Then: 정확히 100이어야 함 (누락 없음)
+        #expect(record.languageCorrectCount == 100, "레코드가 정확히 100이어야 함")
+        #expect(mission.currentValue == 100, "미션 값이 정확히 100이어야 함")
+        #expect(mission.state == .claimable, "미션이 완료되어야 함")
+    }
+
+    @Test("여러 미션 동시 업데이트 시 누락 방지 - 30개 미션")
+    func testMultipleMissionsUpdateWithoutLoss() async throws {
+        // Given: 30개의 미션 생성
+        let missions = (1...30).map { idx in
+            Mission(
+                id: idx,
+                type: .languageMatch(.bronze),
+                title: "미션 \(idx)",
+                description: "테스트 미션",
+                targetValue: 1,
+                updateCondition: { $0.languageCorrectCount },
+                reward: Cost(gold: 100)
+            )
+        }
+        let missionSystem = MissionSystem(missions: missions)
+        let record = Record(missionSystem: missionSystem)
+
+        // When: 1번만 기록
+        record.record(.languageCorrect)
+
+        // 비동기 처리 완료 대기
+        try await Task.sleep(nanoseconds: 100_000_000) // 0.1초
+
+        // Then: 모든 미션이 완료되어야 함 (누락 없음)
+        let completedCount = missions.filter { $0.state == .claimable }.count
+        #expect(completedCount == 30, "30개 미션 모두 완료되어야 함 - 누락 없음")
+        #expect(missionSystem.hasCompletedMission == true, "완료 플래그가 true여야 함")
+    }
+
+    @Test("earnMoney 이벤트로 누적 골드 미션 업데이트")
+    func testEarnMoneyEventMissionUpdate() async throws {
+        // Given: 누적 골드 미션
+        let mission = Mission(
+            id: 100,
+            type: .tap(.gold),
+            title: "1000골드 획득",
+            description: "누적 1000골드 벌기",
+            targetValue: 1000,
+            updateCondition: { $0.totalEarnedMoney },
+            reward: Cost(gold: 500, diamond: 10)
+        )
+        let missionSystem = MissionSystem(missions: [mission])
+        let record = Record(missionSystem: missionSystem)
+
+        // When: 여러 번 골드 획득
+        record.record(.earnMoney(300))
+        record.record(.earnMoney(400))
+        record.record(.earnMoney(300))
+
+        // 비동기 처리 완료 대기
+        try await Task.sleep(nanoseconds: 100_000_000) // 0.1초
+
+        // Then: 정확히 1000이어야 함
+        #expect(record.totalEarnedMoney == 1000, "총 획득 골드가 1000이어야 함")
+        #expect(mission.currentValue == 1000, "미션 값이 1000이어야 함")
+        #expect(mission.state == .claimable, "미션이 완료되어야 함")
+    }
+}


### PR DESCRIPTION
## 연관된 이슈

- closed #281

## 작업 내용 및 고민 내용

- https://github.com/boostcampwm2025/iOS01-Hmm/wiki/미션-업데이트-비동기-전환하기-(결과:-해골물☠%EF%B8%8F)

## 리뷰 요구사항

- 테스트 코드의 불확실한 점이나, 비동기로 전환했을 때 문제점이 없을지 확인 부탁드립니다!
- LanguageGame.swift는 호출되는 곳의 코드를 쉽게 확인하기 위해 줄바꿈으로 `Files changed`에 포함시켰습니다!