### PR TITLE
퀴즈 게임 광고 보상 시스템을 구현합니다.

### DIFF
--- a/SoloDeveloperTraining/SoloDeveloperTraining/GameCore/Models/Games/QuizGame/QuizGame.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/GameCore/Models/Games/QuizGame/QuizGame.swift
@@ -142,6 +142,22 @@ final class QuizGame {
             startQuestion()
         }
     }
+
+    /// 게임 완료 처리
+    /// - Parameter multiplier: 보상 배수 (기본값 1.0, 광고 시청 시 2.0)
+    /// - 타이머 중지
+    /// - 획득한 다이아를 사용자 지갑에 추가 (배수 적용)
+    /// - 게임 상태를 completed로 변경
+    func completeGame(multiplier: Double = 1.0) {
+        stopTimer()
+
+        // 다이아 보상 지급 (정답당 5개 × 배수)
+        let baseDiamonds = correctAnswersCount * Policy.Game.Quiz.diamondsPerCorrect
+        let diamondsToAward = Int(Double(baseDiamonds) * multiplier)
+        user.wallet.addDiamond(diamondsToAward)
+
+        phase = .completed
+    }
 }
 
 private extension QuizGame {
@@ -203,20 +219,6 @@ private extension QuizGame {
             HapticService.shared.trigger(.error)
         }
         phase = .showingExplanation
-    }
-
-    /// 게임 완료 처리
-    /// - 타이머 중지
-    /// - 획득한 다이아를 사용자 지갑에 추가
-    /// - 게임 상태를 completed로 변경
-    func completeGame() {
-        stopTimer()
-
-        // 다이아 보상 지급 (정답당 5개)
-        let diamondsToAward = correctAnswersCount * Policy.Game.Quiz.diamondsPerCorrect
-        user.wallet.addDiamond(diamondsToAward)
-
-        phase = .completed
     }
 
     /// 타이머 시작

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/QuizGameView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/QuizGameView.swift
@@ -305,6 +305,92 @@ private struct RewardPopupView: View {
     }
 }
 
+// MARK: - 퀴즈 광고 팝업 뷰
+private struct QuizAdPopupView: View {
+    let totalDiamondsEarned: Int
+    let onReceiveReward: () -> Void
+    let onWatchAd: () -> Void
+
+    var body: some View {
+        Popup(title: "보상 획득") {
+            VStack(alignment: .center, spacing: 0) {
+                VStack(alignment: .leading, spacing: 0) {
+                    Text("퀴즈 풀이를 완료했습니다!\n진정한 개발자에 한걸음 더 가까워졌습니다.")
+                        .textStyle(.body)
+                        .padding(.top, 11)
+                        .padding(.bottom, 20)
+
+                    HStack(spacing: 4) {
+                        Text("획득한 다이아: ")
+                            .textStyle(.body)
+                        CurrencyLabel(
+                            axis: .horizontal,
+                            icon: .diamond,
+                            textStyle: .body,
+                            value: totalDiamondsEarned
+                        )
+                    }
+                    .padding(.bottom, 20)
+                }
+
+                HStack(spacing: 15) {
+                    MediumButton(title: "2배 받기(AD)", isFilled: true) {
+                        onWatchAd()
+                    }
+
+                    MediumButton(title: "보상 받기", isFilled: true) {
+                        onReceiveReward()
+                    }
+                }
+            }
+        }
+        .padding(.horizontal, 40)
+    }
+}
+
+// MARK: - 퀴즈 보상 완료 팝업 뷰
+private struct QuizRewardPopupView: View {
+    let totalDiamondsEarned: Int
+    let onConfirm: () -> Void
+
+    var body: some View {
+        Popup(title: "보상 지급 완료!") {
+            VStack(spacing: 11) {
+                Text("광고 시청이 완료되었습니다!\n다이아를 2배로 받았습니다.")
+                    .textStyle(.body)
+                    .foregroundColor(.black)
+                    .padding(.horizontal, 20)
+                    .padding(.bottom, 20)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                HStack(spacing: 4) {
+                    Text("획득한 다이아: ")
+                        .textStyle(.body)
+                    CurrencyLabel(
+                        axis: .horizontal,
+                        icon: .diamond,
+                        textStyle: .body,
+                        value: totalDiamondsEarned
+                    )
+                }
+                .padding(.bottom, 30)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 20)
+
+                HStack {
+                    Spacer()
+                    MediumButton(title: "확인", isFilled: true) {
+                        onConfirm()
+                    }
+                    Spacer()
+                }
+            }
+            .frame(maxWidth: .infinity)
+        }
+        .padding(.horizontal, 40)
+    }
+}
+
 #Preview {
     QuizGameView(user: User(
         nickname: "Preview User",

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/QuizGameView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/QuizGameView.swift
@@ -37,7 +37,9 @@ private enum Constant {
 struct QuizGameView: View {
     @Environment(\.dismiss) private var dismiss
     @State private var quizGame: QuizGame
-    @State private var showRewardPopup: Bool = false
+    @State private var showQuizAdPopup: Bool = false
+    @State private var showQuizRewardPopup: Bool = false
+    @State private var finalDiamondsEarned: Int = 0
 
     init(user: User) {
         _quizGame = State(initialValue: QuizGame(user: user))
@@ -84,7 +86,7 @@ struct QuizGameView: View {
                 onSubmit: {
                     if state.phase == .showingExplanation {
                         if state.nextButtonTitle == "보상받기" {
-                            showRewardPopup = true
+                            showQuizAdPopup = true
                         } else {
                             quizGame.proceedToNextQuestion()
                         }
@@ -112,22 +114,82 @@ struct QuizGameView: View {
         }
         .onDisappear { SoundService.shared.stopAllSFX() }
         .overlay {
-            if showRewardPopup {
+            if showQuizAdPopup {
                 ZStack {
                     Color.black.opacity(0.4)
                         .ignoresSafeArea()
 
-                    RewardPopupView(
+                    QuizAdPopupView(
                         totalDiamondsEarned: state.totalDiamondsEarned,
-                        onClose: {
-                            quizGame.proceedToNextQuestion()
-                            showRewardPopup = false
-                            dismiss()
+                        onReceiveReward: {
+                            handleReceiveReward()
+                        },
+                        onWatchAd: {
+                            Task {
+                                await handleWatchAd()
+                            }
                         }
                     )
                 }
             }
         }
+        .overlay {
+            if showQuizRewardPopup {
+                ZStack {
+                    Color.black.opacity(0.4)
+                        .ignoresSafeArea()
+
+                    QuizRewardPopupView(
+                        totalDiamondsEarned: finalDiamondsEarned,
+                        onConfirm: {
+                            handleRewardConfirm()
+                        }
+                    )
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Help Methods
+private extension QuizGameView {
+    /// "보상 받기" 버튼 처리 (광고 없이 기본 보상)
+    func handleReceiveReward() {
+        showQuizAdPopup = false
+
+        // 기본 보상 지급 (1배)
+        quizGame.completeGame(multiplier: 1.0)
+
+        // 게임 종료
+        dismiss()
+    }
+
+    /// "2배 받기(AD)" 버튼 처리 (광고 시청)
+    func handleWatchAd() async {
+        showQuizAdPopup = false
+
+        // 광고 시청
+        let success = await AdService.shared.showAdWithResult(.interstitial)
+
+        if success {
+            // 2배 보상 지급
+            let baseDiamonds = quizGame.state.totalDiamondsEarned
+            finalDiamondsEarned = baseDiamonds * 2
+            quizGame.completeGame(multiplier: 2.0)
+
+            // 보상 완료 팝업 표시
+            showQuizRewardPopup = true
+        } else {
+            // 광고 실패 시 기본 보상 지급하고 종료
+            quizGame.completeGame(multiplier: 1.0)
+            dismiss()
+        }
+    }
+
+    /// "확인" 버튼 처리 (보상 완료 팝업)
+    func handleRewardConfirm() {
+        showQuizRewardPopup = false
+        dismiss()
     }
 }
 
@@ -267,41 +329,6 @@ private struct QuizOptionsView: View {
             }
             .padding(.bottom, Constant.Padding.submitBottom)
         }
-    }
-}
-
-// MARK: - 보상 팝업 뷰
-private struct RewardPopupView: View {
-    let totalDiamondsEarned: Int
-    let onClose: () -> Void
-
-    var body: some View {
-        Popup(title: "보상 획득") {
-            VStack(alignment: .center, spacing: 0) {
-                VStack(alignment: .leading, spacing: 0) {
-                    Text("퀴즈 풀이를 완료했습니다!\n진정한 개발자에 한걸음 더 가까워졌습니다.")
-                        .textStyle(.body)
-                        .padding(.top, 11)
-                        .padding(.bottom, 20)
-
-                    HStack(spacing: 4) {
-                        Text("획득한 다이아: ")
-                            .textStyle(.body)
-                        CurrencyLabel(
-                            axis: .horizontal,
-                            icon: .diamond,
-                            textStyle: .body,
-                            value: totalDiamondsEarned
-                        )
-                    }
-                    .padding(.bottom, 20)
-                }
-                MediumButton(title: "종료하기", isFilled: true) {
-                    onClose()
-                }
-            }
-        }
-        .padding(.horizontal, 40)
     }
 }
 


### PR DESCRIPTION
## 연관된 이슈

- [KAN-53](https://devvup.atlassian.net/jira/software/projects/KAN/boards/1/backlog?selectedIssue=KAN-53)

## 작업 내용 및 고민 내용

### 1. QuizGame 보상 배수 기능 추가
- `completeGame(multiplier: Double = 1.0)`와 같이 메서드에 배수 파라미터 추가
- 기본값 1.0으로 기존 로직 유지
- 광고 시청 시 `multiplier: 2.0` 전달하여 2배 보상 지급

### 2. 광고 선택 UI 구현
- `QuizAdPopupView`: 퀴즈 완료 시 표시되는 선택 팝업
  - "보상 받기" 버튼: 기본 보상(1배) 즉시 지급 후 종료
  - "2배 받기(AD)" 버튼: 광고 시청 진행
- `QuizRewardPopupView`: 광고 시청 완료 후 표시되는 확인 팝업
  - 2배로 증가된 다이아 수 표시
  - "확인" 버튼으로 게임 종료

### 3. 광고 통합 로직
- 기존 AdService.shared.showAdWithResult(.interstitial) 패턴 활용
- 광고 시청 성공: 2배 보상 지급 → 보상 완료 팝업 표시
- 광고 시청 실패/취소: 기본 보상(1배) 지급 후 게임 종료

### 4. 고민 내용

#### `completeGame()` 접근 제어자 변경
- 고민
  - 기존에는 `QuizGame` 내부에서 보상 지급 타이밍을 모두 제어했습니다.
  하지만 광고 시청 여부에 따라 보상 배수를 다르게 적용해야 하므로,
  외부(`QuizGameView`)에서 보상 지급을 제어할 수 있어야 했습니다.
- 결정
  - `completeGame(multiplier:)`을 public으로 변경하여 외부 접근 가능하도록 변경하되,  
  `proceedToNextQuestion()`에서는 기존 동작을 유지했습니다.
- 이유
  - 광고 시청 후 `QuizGameView`에서 직접 `completeGame(multiplier: 2.0)` 호출 가능
  (보상 지급 타이밍을 외부에서 제어 가능하도록 책임 분리)
  - 기존 플로우는 그대로 유지

## 스크린샷

https://github.com/user-attachments/assets/86f79219-5eec-4ca6-b30b-bff329313b5c

## 리뷰 요구사항
- 고민 사항에 대해서 코멘트 달게 있다면 부탁드립니다!