### PR TITLE
전면형 광고 단위 ID 분기를 추가합니다.

### DIFF
--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Advertisement/AdService.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Advertisement/AdService.swift
@@ -19,6 +19,7 @@ final class AdService {
 
     private let factory: AdFactory
     private var loadedAds: [AdType: AdUnit] = [:]
+    private var loadingTasks: [AdType: Task<AdUnit?, Never>] = [:]
     private var isShowing = false
 
     init(factory: AdFactory) {
@@ -27,13 +28,7 @@ final class AdService {
 
     // 광고 로드
     func loadAd(_ type: AdType) async {
-        let ads = factory.makeAdUnit(for: type)
-        do {
-            try await ads.load()
-            loadedAds[type] = ads
-        } catch {
-            print("❌ Ad load failed: \(error.localizedDescription)")
-        }
+        await loadAdIfNeeded(type)
     }
 
     // 광고 표시 후 결과 반환 (true: 정상 시청 완료, false: 실패)
@@ -44,13 +39,13 @@ final class AdService {
 
         await requestTrackingAuthorizationIfNeeded()
 
-        guard let ads = await getOrLoadAd(type) else {
+        guard let ads = await loadAdIfNeeded(type) else {
             print("⚠️ Ad not ready")
             return false
         }
 
-        let result = await ads.showWithResult()
         loadedAds.removeValue(forKey: type)
+        let result = await ads.showWithResult()
 
         Task {
             await loadAd(type)
@@ -61,6 +56,46 @@ final class AdService {
 }
 
 private extension AdService {
+    @discardableResult
+    func loadAdIfNeeded(_ type: AdType) async -> AdUnit? {
+        if let ads = loadedAds[type], ads.isReady {
+            return ads
+        }
+
+        // 이미 로딩중인 광고가 있는 경우, 추가 요청 없이 기다린 후 받아옵니다.
+        if let loadingTask = loadingTasks[type] {
+            let ads = await loadingTask.value
+            if let ads {
+                loadedAds[type] = ads
+            }
+            return ads
+        }
+
+        let loadingTask = Task<AdUnit?, Never> {
+            let ads = self.factory.makeAdUnit(for: type)
+            do {
+                try await ads.load()
+                return ads
+            } catch {
+                print("❌ Ad load failed: \(error.localizedDescription)")
+                return nil
+            }
+        }
+
+        loadingTasks[type] = loadingTask
+
+        let ads = await loadingTask.value
+        loadingTasks[type] = nil
+
+        if let ads {
+            loadedAds[type] = ads
+        } else {
+            loadedAds.removeValue(forKey: type)
+        }
+
+        return ads
+    }
+
     func requestTrackingAuthorizationIfNeeded() async {
         // 이미 ATT 요청했거나, iOS 14.5 미만이면 무시
         guard #available(iOS 14.5, *), ATTrackingManager.trackingAuthorizationStatus == .notDetermined else {
@@ -75,13 +110,5 @@ private extension AdService {
         @unknown default:
             break
         }
-    }
-
-    func getOrLoadAd(_ type: AdType) async -> AdUnit? {
-        if let ads = loadedAds[type], ads.isReady {
-            return ads
-        }
-        await loadAd(type)
-        return loadedAds[type]
     }
 }

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Advertisement/AdUnit.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Advertisement/AdUnit.swift
@@ -8,6 +8,5 @@
 protocol AdUnit {
     var isReady: Bool { get }
     @MainActor func load() async throws
-    @MainActor func show() async
     @MainActor func showWithResult() async -> Bool
 }

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Advertisement/InterstitialAdUnit.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Advertisement/InterstitialAdUnit.swift
@@ -9,9 +9,15 @@ import GoogleMobileAds
 
 final class InterstitialAdUnit: NSObject, AdUnit {
     private var interstitialAd: InterstitialAd?
-    private var adUnitID: String = "ca-app-pub-3940256099942544/4411468910"
-    private var continuation: CheckedContinuation<Void, Never>?
     private var resultContinuation: CheckedContinuation<Bool, Never>?
+
+    var adUnitID: String {
+        #if DEBUG
+            "ca-app-pub-3940256099942544/4411468910"
+        #else
+            "ca-app-pub-xxxxxxxxxxxxxxxx/xxxxxxxxxx"  // 실제 ID
+        #endif
+    }
 
     var isReady: Bool {
         return interstitialAd != nil
@@ -25,28 +31,12 @@ final class InterstitialAdUnit: NSObject, AdUnit {
         interstitialAd?.fullScreenContentDelegate = self
     }
 
-    func show() async {
-        guard let interstitialAd else {
-            print("❌ Ad not ready")
-            return
-        }
-        guard continuation == nil else {
-            print("⚠️ Ad is already showing")
-            return
-        }
-
-        await withCheckedContinuation { continuation in
-            self.continuation = continuation
-            interstitialAd.present(from: nil)
-        }
-    }
-
     func showWithResult() async -> Bool {
         guard let interstitialAd else {
             print("❌ Ad not ready")
             return false
         }
-        guard continuation == nil, resultContinuation == nil else {
+        guard resultContinuation == nil else {
             print("⚠️ Ad is already showing")
             return false
         }
@@ -66,8 +56,6 @@ extension InterstitialAdUnit: FullScreenContentDelegate {
         didFailToPresentFullScreenContentWithError error: Error
     ) {
         print("\(#function) called")
-        continuation?.resume()
-        continuation = nil
         resultContinuation?.resume(returning: false)
         resultContinuation = nil
         interstitialAd = nil
@@ -76,8 +64,6 @@ extension InterstitialAdUnit: FullScreenContentDelegate {
     // 광고 화면이 닫혔을 경우
     func adDidDismissFullScreenContent(_ ads: FullScreenPresentingAd) {
         print("\(#function) called")
-        continuation?.resume()
-        continuation = nil
         resultContinuation?.resume(returning: true)
         resultContinuation = nil
         interstitialAd = nil

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Advertisement/InterstitialAdUnit.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Advertisement/InterstitialAdUnit.swift
@@ -15,7 +15,7 @@ final class InterstitialAdUnit: NSObject, AdUnit {
         #if DEBUG
             "ca-app-pub-3940256099942544/4411468910"
         #else
-            "ca-app-pub-xxxxxxxxxxxxxxxx/xxxxxxxxxx"  // 실제 ID
+        Secret.interstitialAdUnitID  // 실제 ID
         #endif
     }
 

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Advertisement/InterstitialAdUnit.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Advertisement/InterstitialAdUnit.swift
@@ -20,7 +20,7 @@ final class InterstitialAdUnit: NSObject, AdUnit {
     }
 
     var isReady: Bool {
-        return interstitialAd != nil
+        return interstitialAd != nil && resultContinuation == nil
     }
 
     func load() async throws {

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/SkillView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/SkillView.swift
@@ -77,9 +77,6 @@ struct SkillView: View {
         .onAppear {
             AnalyticsService.shared.logScreenView(screenName: "skill")
         }
-        .task {
-            await AdService.shared.loadAd(.interstitial)
-        }
     }
 }
 


### PR DESCRIPTION
## 연관된 이슈

- [KAN-71](https://devvup.atlassian.net/browse/KAN-71)

## 작업 내용 및 고민 내용
### 전면형 광고 단위 재사용 가능 여부 검토
- 전면형 광고의 경우, 하나의 광고 단위를 여러 위치에서 사용해도 문제 없는 것으로 확인하여 관리 복잡도를 최소화하기 위해 광고 단위는 1개만 생성하고 사용했습니다.

### 실제 광고 단위 ID 분기 추가 
- 컴파일 플래그를 통해 디버그 환경과 릴리즈 환경을 구분하여 분기처리했습니다.

### 광고 단위 ID 비공개 설정 방식 논의
- Admob에 등록한 앱의 식별자인 앱 ID의 경우 노출되어도 크게 상관없지만, (이미 광고 표시에 필요한 ads.txt 파일에 공개된 값)
실제 사용하는 광고 단위의 ID의 경우 노출될 경우 악용될 여지가 있는 것으로 확인했습니다.
- 따라서 가장 안전하다고 생각되는 `Secret.swift` 파일에 상수 값을 저장하고, 해당 파일을 .gitignore에 추가하는 방식으로 구현했습니다. 더 나은 방식이 있다면 의견 부탁드립니다!

### 테스트 기기 등록 요청 배경
- 일반적으로 Xcode 내에서 빌드시 DEBUG 모드로 동작하여 테스트용 ID를 쓰게 되지만, 테스트 플라이트 배포와 같이 아카이브 후 테스트 하는 경우, 혹시 모를 경우에 대비해 안전하게 모든 팀원분들의 기기를 테스트 기기로 등록하는게 적절하다고 판단하여 요청드리게 되었습니다! 
 +) 시뮬레이터의 경우 자동으로 테스트 기기로 인식된다고 합니다!

### 광고 중복 로드 문제 개선
- 기존 AdService 객체 내의 광고를 로드하고 표시하는 로직에서, '요청 중인 작업'에 대한 관리의 부재로 중복 광고 요청 문제의 여지가 존재하는 것을 확인했습니다.

```swift
  let ads = factory.makeAdUnit(for: type)
  try await ads.load()
  loadedAds[type] = ads
```
  기존 코드의 문제는 try await ads.load() 중에 함수가 suspend 된다는 점입니다. 그 사이 다른 화면이나 다른 .task에서 loadAd(.interstitial)가 또 호출되면, 기존 로딩이 끝나기 전에 새 InterstitialAdUnit을 만들고 또 로드 요청을 보낼 수 있었습니다. 결과적으로 같은 광고 타입에 대해 중복 네트워크 요청이 생기고, 마지막에 완료된 요청이 loadedAds[type]를 덮어쓰는 구조였습니다.

  따라서 loadingTasks 변수를 추가했습니다. 해당 변수는 광고 타이별로 광고를 로드하는 Task 자체를 저장합니다.

  ```swift
private var loadingTasks: [AdType: Task<AdUnit?, Never>] = [:]
```
  그리고 loadAdIfNeeded(_:)에서 다음 순서로 처리합니다.
```swift

  if let ads = loadedAds[type], ads.isReady { // 이미 준비된 광고가 있으면 추가 로드 없이 그대로 반환합니다.
      return ads
  }

  if let loadingTask = loadingTasks[type] { // 이미 같은 타입의 광고가 로딩 중이면 새 요청을 만들지 않고, 진행 중인 작업의 결과를 기다립니다.
      let ads = await loadingTask.value
      if let ads {
          loadedAds[type] = ads
      }
      return ads
  }

  let loadingTask = Task<AdUnit?, Never> { // 로딩 중인 작업이 없을 때만 새 광고 객체를 만들고 로드합니다.
      let ads = self.factory.makeAdUnit(for: type)
      try await ads.load()
      return ads
  }

  loadingTasks[type] = loadingTask
```

  요약하면 개선 후 동작은 이렇게 정리됩니다.

  - 준비된 광고 있음 -> 기존 광고 반환
  - 로딩 중인 광고 있음 -> 기존 로딩 작업 기다림
  - 준비/로딩 둘 다 없음 -> 새 광고 로드

## 리뷰 요구사항
- 좋다고 생각하는 광고 단위 ID 비공개 설정 방식