### PR TITLE
성장 카테고리의 이벤트 로그를 정의합니다. (my_app_first_open, app_opened, session_ended)

### DIFF
--- a/SoloDeveloperTraining/SoloDeveloperTraining/App/SoloDeveloperTrainingApp.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/App/SoloDeveloperTrainingApp.swift
@@ -137,6 +137,7 @@ private extension SoloDeveloperTrainingApp {
                 if let loadedUser = try await userRepository.load() {
                     await MainActor.run {
                         self.user = loadedUser
+                        checkFirstOpen(user: loadedUser)
                     }
                 }
             } catch {
@@ -242,3 +243,16 @@ private extension SoloDeveloperTrainingApp {
     }
 }
 #endif
+
+// MARK: - Helper
+
+private extension SoloDeveloperTrainingApp {
+
+    // MARK: - Analytics
+
+    func checkFirstOpen(user: User) {
+        guard !AnalyticsKeychain.hasLoggedFirstOpen() else { return }
+        AnalyticsKeychain.markFirstOpenLogged()
+        AnalyticsService.shared.logFirstOpen(level: user.career.level)
+    }
+}

--- a/SoloDeveloperTraining/SoloDeveloperTraining/App/SoloDeveloperTrainingApp.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/App/SoloDeveloperTrainingApp.swift
@@ -195,15 +195,19 @@ private extension SoloDeveloperTrainingApp {
 
                 NicknameSetupView(
                     onStart: { nickname in
-                        user = User(nickname: nickname)
+                        let newUser = User(nickname: nickname)
+                        user = newUser
                         showNicknameSetup = false
+                        checkFirstOpen(user: newUser)
                         withAnimation(.easeOut(duration: Constant.Animation.transitionDuration)) {
                             hasSeenIntro = true
                         }
                     },
                     onTutorial: { nickname in
-                        user = User(nickname: nickname)
+                        let newUser = User(nickname: nickname)
+                        user = newUser
                         showNicknameSetup = false
+                        checkFirstOpen(user: newUser)
                         showTutorial = true
                     }
                 )
@@ -252,10 +256,6 @@ private extension SoloDeveloperTrainingApp {
 
     func checkFirstOpen(user: User) {
         guard !AnalyticsKeychain.hasLoggedFirstOpen() else { return }
-        guard user.nickname.isEmpty else {
-            AnalyticsKeychain.markFirstOpenLogged()
-            return
-        }
         AnalyticsKeychain.markFirstOpenLogged()
         AnalyticsService.shared.logFirstOpen(level: user.career.level)
     }

--- a/SoloDeveloperTraining/SoloDeveloperTraining/App/SoloDeveloperTrainingApp.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/App/SoloDeveloperTrainingApp.swift
@@ -255,8 +255,8 @@ private extension SoloDeveloperTrainingApp {
     // MARK: - Analytics
 
     func checkFirstOpen(user: User) {
-        guard !AnalyticsKeychain.hasLoggedFirstOpen() else { return }
-        AnalyticsKeychain.markFirstOpenLogged()
+        guard AnalyticsKeychain.isNewInstall() else { return }
+        AnalyticsKeychain.getOrCreateDeviceID()
         AnalyticsService.shared.logFirstOpen(level: user.career.level)
     }
 }

--- a/SoloDeveloperTraining/SoloDeveloperTraining/App/SoloDeveloperTrainingApp.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/App/SoloDeveloperTrainingApp.swift
@@ -252,6 +252,10 @@ private extension SoloDeveloperTrainingApp {
 
     func checkFirstOpen(user: User) {
         guard !AnalyticsKeychain.hasLoggedFirstOpen() else { return }
+        guard user.nickname.isEmpty else {
+            AnalyticsKeychain.markFirstOpenLogged()
+            return
+        }
         AnalyticsKeychain.markFirstOpenLogged()
         AnalyticsService.shared.logFirstOpen(level: user.career.level)
     }

--- a/SoloDeveloperTraining/SoloDeveloperTraining/GameCore/Models/User/Career.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/GameCore/Models/User/Career.swift
@@ -131,3 +131,11 @@ extension Career {
         }
     }
 }
+
+// MARK: - Analytics
+extension Career {
+    /// Analytics 이벤트용 레벨 (1부터 시작)
+    var level: Int {
+        (Career.allCases.firstIndex(of: self) ?? 0) + 1
+    }
+}

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AnalyticsKeychain.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AnalyticsKeychain.swift
@@ -9,16 +9,14 @@ import Foundation
 
 enum AnalyticsKeychain {
 
-    /// first_open 이미 로깅됐는지 확인
-    static func hasLoggedFirstOpen(deviceID: String) -> Bool {
-        let key = "first_open_logged_\(deviceID)"
-        return load(key: key) != nil
+    private static let firstOpenKey = "first_open_logged"
+
+    static func hasLoggedFirstOpen() -> Bool {
+        return load(key: firstOpenKey) != nil
     }
 
-    /// first_open 로깅 완료 표시
-    static func markFirstOpenLogged(deviceID: String) {
-        let key = "first_open_logged_\(deviceID)"
-        save(key: key, value: "true")
+    static func markFirstOpenLogged() {
+        save(key: firstOpenKey, value: "true")
     }
 
     // MARK: - Private

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AnalyticsKeychain.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AnalyticsKeychain.swift
@@ -9,14 +9,22 @@ import Foundation
 
 enum AnalyticsKeychain {
 
-    private static let firstOpenKey = "first_open_logged"
+    private static let deviceIDKey = "analytics_device_id"
 
-    static func hasLoggedFirstOpen() -> Bool {
-        return load(key: firstOpenKey) != nil
+    /// Keychain에 저장된 device_id 반환, 없으면 UUID 생성 후 저장
+    @discardableResult
+    static func getOrCreateDeviceID() -> String {
+        if let existing = load(key: deviceIDKey) {
+            return existing
+        }
+        let newID = UUID().uuidString
+        save(key: deviceIDKey, value: newID)
+        return newID
     }
 
-    static func markFirstOpenLogged() {
-        save(key: firstOpenKey, value: "true")
+    /// Keychain에 device_id가 없었으면 true (신규/재설치 유저)
+    static func isNewInstall() -> Bool {
+        return load(key: deviceIDKey) == nil
     }
 
     // MARK: - Private

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AnalyticsKeychain.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AnalyticsKeychain.swift
@@ -1,0 +1,49 @@
+//
+//  AnalyticsKeychain.swift
+//  SoloDeveloperTraining
+//
+//  Created by 김성훈 on 6/1/26.
+//
+
+import Foundation
+
+enum AnalyticsKeychain {
+
+    /// first_open 이미 로깅됐는지 확인
+    static func hasLoggedFirstOpen(deviceID: String) -> Bool {
+        let key = "first_open_logged_\(deviceID)"
+        return load(key: key) != nil
+    }
+
+    /// first_open 로깅 완료 표시
+    static func markFirstOpenLogged(deviceID: String) {
+        let key = "first_open_logged_\(deviceID)"
+        save(key: key, value: "true")
+    }
+
+    // MARK: - Private
+
+    private static func save(key: String, value: String) {
+        let data = Data(value.utf8)
+        let query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrAccount: key,
+            kSecValueData: data
+        ]
+        SecItemDelete(query as CFDictionary)
+        SecItemAdd(query as CFDictionary, nil)
+    }
+
+    private static func load(key: String) -> String? {
+        let query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrAccount: key,
+            kSecReturnData: true,
+            kSecMatchLimit: kSecMatchLimitOne
+        ]
+        var result: AnyObject?
+        SecItemCopyMatching(query as CFDictionary, &result)
+        guard let data = result as? Data else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+}

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AnalyticsProperty.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AnalyticsProperty.swift
@@ -23,6 +23,21 @@ enum AnalyticsProperty {
     static let deviceModel = "device_model"
     /// 현재 사용자 레벨
     static let level = "level"
+    /// 사용자 닉네임
+    static let nickname = "nickname"
+
+    // MARK: - Event Properties
+
+    /// 유입 경로
+    static let entrySource = "entry_source"
+    /// 유입을 만든 원 공유 ID
+    static let referrerShareID = "referrer_share_id"
+    /// 설치 후 딥링크 유입 여부
+    static let isDeferredDeeplink = "is_deferred_deeplink"
+    /// 세션 체류시간
+    static let sessionDurationSec = "session_duration_sec"
+    /// 세션 종료 전 마지막 화면
+    static let lastScreen = "last_screen"
 
 }
 

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AnalyticsProperty.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AnalyticsProperty.swift
@@ -43,9 +43,9 @@ enum AnalyticsProperty {
 
 // MARK: - Device Values
 extension AnalyticsProperty {
-    /// UIDevice.identifierForVendor 기반 기기 고유 식별자
+    /// Keychain 기반 앱 고유 식별자 (UUID)
     static var deviceIDValue: String {
-        UIDevice.current.identifierForVendor?.uuidString ?? "unknown"
+        AnalyticsKeychain.getOrCreateDeviceID()
     }
 
     /// CFBundleShortVersionString 기반 앱 버전

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AnalyticsProperty.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AnalyticsProperty.swift
@@ -1,0 +1,50 @@
+//
+//  AnalyticsProperty.swift
+//  SoloDeveloperTraining
+//
+//  Created by 김성훈 on 6/1/26.
+//
+
+import UIKit
+
+enum AnalyticsProperty {
+
+    // MARK: - User Properties
+
+    /// 기기 고유 식별자
+    static let deviceID = "device_id"
+    /// 앱 사용 세션 식별자
+    static let sessionID = "session_id"
+    /// 앱 버전
+    static let appVersion = "app_version"
+    /// 사용 중인 iOS 버전
+    static let osVersion = "os_version"
+    /// 사용 기기 모델
+    static let deviceModel = "device_model"
+    /// 현재 사용자 레벨
+    static let level = "level"
+
+}
+
+// MARK: - Device Values
+extension AnalyticsProperty {
+    /// UIDevice.identifierForVendor 기반 기기 고유 식별자
+    static var deviceIDValue: String {
+        UIDevice.current.identifierForVendor?.uuidString ?? "unknown"
+    }
+
+    /// CFBundleShortVersionString 기반 앱 버전
+    static var appVersionValue: String {
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
+    }
+
+    /// UIDevice.systemVersion 기반 iOS 버전
+    static var osVersionValue: String {
+        "iOS \(UIDevice.current.systemVersion)"
+    }
+
+    /// UIDevice.localizedModel 기반 기기 모델명
+    static var deviceModelValue: String {
+        UIDevice.current.localizedModel
+    }
+}

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AnalyticsService.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AnalyticsService.swift
@@ -18,7 +18,7 @@ final class AnalyticsService {
 
     /// device_id 기준 첫 앱 실행 (앱 재설치 시에도 1회만)
     func logFirstOpen(level: Int) {
-        Analytics.logEvent("first_open", parameters: [
+        Analytics.logEvent("my_app_first_open", parameters: [
             AP.deviceID: AP.deviceIDValue,
             AP.sessionID: SessionManager.shared.sessionID,
             AP.appVersion: AP.appVersionValue,

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AnalyticsService.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AnalyticsService.swift
@@ -20,7 +20,7 @@ final class AnalyticsService {
     func logFirstOpen(level: Int) {
         Analytics.logEvent("first_open", parameters: [
             AP.deviceID: AP.deviceIDValue,
-            AP.sessionID: "pending",
+            AP.sessionID: SessionManager.shared.sessionID,
             AP.appVersion: AP.appVersionValue,
             AP.osVersion: AP.osVersionValue,
             AP.deviceModel: AP.deviceModelValue,

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AnalyticsService.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AnalyticsService.swift
@@ -7,49 +7,24 @@
 
 import FirebaseAnalytics
 
+private typealias AP = AnalyticsProperty
+
 final class AnalyticsService {
     static let shared = AnalyticsService()
 
     private init() {}
 
-    // MARK: - Screen View
+    // MARK: - 성장
 
-    /// 화면 조회 이벤트
-    /// 사용 위치: 주요 View의 .onAppear
-    func logScreenView(screenName: String) {
-        Analytics.logEvent(AnalyticsEventScreenView, parameters: [
-            AnalyticsParameterScreenName: screenName
+    /// device_id 기준 첫 앱 실행 (앱 재설치 시에도 1회만)
+    func logFirstOpen(level: Int) {
+        Analytics.logEvent("first_open", parameters: [
+            AP.deviceID: AP.deviceIDValue,
+            AP.sessionID: "pending",
+            AP.appVersion: AP.appVersionValue,
+            AP.osVersion: AP.osVersionValue,
+            AP.deviceModel: AP.deviceModelValue,
+            AP.level: level
         ])
-    }
-
-    // MARK: - Game Events
-
-    /// 게임 시작 이벤트
-    /// 사용 위치: 각 게임 View에서 게임 시작 시
-    func logGameStart(gameType: GameType) {
-        Analytics.logEvent("game_start", parameters: [
-            "game_type": gameType.analyticsValue
-        ])
-    }
-
-    // MARK: - User Engagement
-
-    /// 튜토리얼 완료 이벤트
-    /// 사용 위치: TutorialView 완료 시
-    func logTutorialComplete() {
-        Analytics.logEvent(AnalyticsEventTutorialComplete, parameters: nil)
-    }
-}
-
-// MARK: - Analytics Extensions
-
-private extension GameType {
-    var analyticsValue: String {
-        switch self {
-        case .tap: return "tap"
-        case .language: return "language"
-        case .dodge: return "dodge"
-        case .stack: return "stack"
-        }
     }
 }

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AnalyticsService.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AnalyticsService.swift
@@ -27,4 +27,37 @@ final class AnalyticsService {
             AP.level: level
         ])
     }
+
+    /// 매 실행마다 카운트
+    func logAppOpened(
+        nickname: String,
+        level: Int,
+        entrySource: String,
+        referrerShareID: String,
+        isDeferredDeeplink: Bool
+    ) {
+        Analytics.logEvent("app_opened", parameters: [
+            AP.deviceID: AP.deviceIDValue,
+            AP.sessionID: SessionManager.shared.sessionID,
+            AP.nickname: nickname,
+            AP.appVersion: AP.appVersionValue,
+            AP.osVersion: AP.osVersionValue,
+            AP.deviceModel: AP.deviceModelValue,
+            AP.entrySource: entrySource,
+            AP.referrerShareID: referrerShareID,
+            AP.isDeferredDeeplink: isDeferredDeeplink,
+            AP.level: level
+        ])
+    }
+
+    /// 사용자가 앱 사용을 종료하거나 세션 만료
+    func logSessionEnded(level: Int, lastScreen: String) {
+        Analytics.logEvent("session_ended", parameters: [
+            AP.deviceID: AP.deviceIDValue,
+            AP.sessionID: SessionManager.shared.sessionID,
+            AP.sessionDurationSec: SessionManager.shared.sessionDurationSec,
+            AP.lastScreen: lastScreen,
+            AP.level: level
+        ])
+    }
 }

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/SessionManager.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/SessionManager.swift
@@ -1,0 +1,48 @@
+//
+//  SessionManager.swift
+//  SoloDeveloperTraining
+//
+//  Created by 김성훈 on 6/1/26.
+//
+
+import Foundation
+
+final class SessionManager {
+    static let shared = SessionManager()
+
+    private init() {}
+
+    private(set) var sessionID: String = SessionManager.generateSessionID()
+    private var sessionStartTime: Date = Date()
+    private var backgroundedAt: Date?
+
+    private static let sessionTimeoutSeconds: TimeInterval = 60
+
+    // MARK: - App Lifecycle
+
+    func handleForeground() {
+        if let backgroundedAt, Date().timeIntervalSince(backgroundedAt) > SessionManager.sessionTimeoutSeconds {
+            sessionID = SessionManager.generateSessionID()
+            sessionStartTime = Date()
+        }
+        self.backgroundedAt = nil
+    }
+
+    func handleBackground() {
+        backgroundedAt = Date()
+    }
+
+    // MARK: - Session Duration
+
+    var sessionDurationSec: Int {
+        Int(Date().timeIntervalSince(sessionStartTime))
+    }
+
+    // MARK: - Private
+
+    private static func generateSessionID() -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyyMMdd_HHmmss"
+        return "sess_\(formatter.string(from: Date()))_\(UUID().uuidString.prefix(6))"
+    }
+}

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Intro/TutorialView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Intro/TutorialView.swift
@@ -137,7 +137,6 @@ private extension TutorialView {
                 }
             } else {
                 MediumButton(title: "시작하기", isFilled: true) {
-                    AnalyticsService.shared.logTutorialComplete()
                     onComplete()
                 }
             }

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/MainView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/MainView.swift
@@ -281,7 +281,6 @@ private extension MainView {
     }
 
     func setupOnAppear() {
-        AnalyticsService.shared.logScreenView(screenName: "main")
         SoundService.shared.playBGM()
         skillAdRewardNow = Date()
         autoGainSystem.startSystem()

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/MissionView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/MissionView.swift
@@ -59,9 +59,6 @@ struct MissionView: View {
         }
         .padding(.horizontal)
         .toast(isShowing: $showToast, message: toastMessage)
-        .onAppear {
-            AnalyticsService.shared.logScreenView(screenName: "mission")
-        }
     }
 }
 

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/ShopView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/ShopView.swift
@@ -74,9 +74,6 @@ struct ShopView: View {
                 housingView
             }
         }
-        .onAppear {
-            AnalyticsService.shared.logScreenView(screenName: "shop")
-        }
         .darkToast(isShowing: $showAdBonusToast, message: "강화 확률이 높아졌습니다!")
     }
 }

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/SkillView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/SkillView.swift
@@ -74,9 +74,6 @@ struct SkillView: View {
         }
         .padding(.bottom)
         .scrollIndicators(.never)
-        .onAppear {
-            AnalyticsService.shared.logScreenView(screenName: "skill")
-        }
     }
 }
 

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Work/Game/DodgeGameView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Work/Game/DodgeGameView.swift
@@ -98,7 +98,6 @@ struct DodgeGameView: View {
                 // (광고에서 돌아올 때 게임이 자동으로 재개되는 것을 방지)
                 guard !isGameInitialized else { return }
 
-                AnalyticsService.shared.logGameStart(gameType: .dodge)
                 setupGame(with: geometry.size)
                 isGameInitialized = true
 

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Work/Game/LanguageGameView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Work/Game/LanguageGameView.swift
@@ -118,7 +118,6 @@ struct LanguageGameView: View {
                 Spacer()
             }
             .onAppear {
-                AnalyticsService.shared.logGameStart(gameType: .language)
                 // 게임 재개 콜백 설정
                 resumeGameCallback = { [weak game] in
                     game?.resumeGame()

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Work/Game/QuizGameView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Work/Game/QuizGameView.swift
@@ -101,7 +101,6 @@ struct QuizGameView: View {
         .background(AppColors.beige100)
         .onAppear {
             if quizGame.state.phase == .ready {
-                AnalyticsService.shared.logScreenView(screenName: "quiz")
                 quizGame.startGame()
             }
         }

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Work/Game/StackGameView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Work/Game/StackGameView.swift
@@ -81,7 +81,6 @@ struct StackGameView: View {
             .background(AppTheme.backgroundColor)
             .navigationBarBackButtonHidden(true) // 임시로 숨김
             .onAppear {
-                AnalyticsService.shared.logGameStart(gameType: .stack)
                 setupGameCallbacks(with: geometry)
                 // 게임 재개 콜백 설정
                 resumeGameCallback = { [weak scene] in

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Work/Game/TapGameView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Work/Game/TapGameView.swift
@@ -80,7 +80,6 @@ struct TapGameView: View {
                 tapAreaSection(geometry: geometry)
             }
             .onAppear {
-                AnalyticsService.shared.logGameStart(gameType: .tap)
                 // 게임 재개 콜백 설정
                 resumeGameCallback = { [weak tapGame] in
                     tapGame?.resumeGame()


### PR DESCRIPTION
## 연관된 이슈

- [KAN-99](https://devvup.atlassian.net/jira/software/projects/KAN/boards/1/backlog?selectedIssue=KAN-99)
  - [KAN-100](https://devvup.atlassian.net/jira/software/projects/KAN/boards/1/backlog?selectedIssue=KAN-100)
  - [KAN-101](https://devvup.atlassian.net/jira/software/projects/KAN/boards/1/backlog?selectedIssue=KAN-101)
  - [KAN-102](https://devvup.atlassian.net/jira/software/projects/KAN/boards/1/backlog?selectedIssue=KAN-102)

## 작업 내용 및 고민 내용

### 성장 카테고리 이벤트 3개 정의<br>(`my_app_first_open`, `app_opened`, `session_ended`)

- 구조
  - `AnalyticsService.swift`: 이벤트 정의
  - `AnalyticsProperty.swift`: 프로퍼티 키 및 기기 값 정의
  - `SessionManager.swift`: 세션 ID 생성 및 체류시간 관리
  - `AnalyticsKeychain.swift`: `my_app_first_open` 중복 방지용 Keychain 저장

### `my_app_first_open` 이벤트 연동
- `my_app_first_open`은 이벤트 정의 뿐만 아니라 호출 부분까지 완료하였습니다.
- 이벤트 정의서 기준으로 `my_app_first_open` 파라미터에 `level`이 포함되어 있어,  
유저 객체가 생성/로드되는 시점에 호출이 필요했습니다. 그래서 호출부가 아래 두 곳으로 나뉘어졌습니다.
  - 신규 유저: nicknameSetupOverlay의 onStart / onTutorial
  - 기존 유저: loadUser() 완료 시점
- 고려한 케이스
  - 신규 유저: 닉네임 설정(`onStart`/`onTutorial`) 시점에 로깅
  - 기존 유저 (업데이트 후 첫 실행): `loadUser()` 완료 시점에 Keychain 확인 후 기록이 없으면 그 시점의 레벨로 로깅
  - 재실행 유저: Keychain에 기록이 있으므로 스킵
- Keychain에 IDFV 값이 아닌 설치 여부(Bool)를 저장했습니다
  - IDFV는 개발사 앱이 모두 삭제된 상태에서 재설치하면 값이 변경되기 때문에<br>IDFV를 키로 사용하면 재설치 후 Keychain에 값이 있어도 조회가 안되는 문제가 있습니다
  - 고정 키로 Bool 값만 저장해 이 문제를 우회하여 해결했습니다.
- `first_open`은 Firebase 예약어라 `my_app_first_open`으로 커스텀 이름을 사용했습니다.(구글 시트 변경 완료)
- (앱이 삭제되면 Keychain데이터도 삭제된다고 알고 있었는데)Keychain이 앱 삭제 후에도 값이 유지되는 경우가 많아 이를 활용했습니다.
  - 다만 Apple이 공식적으로 보장하는 동작이 아니라서 현재는 정상적으로 동작할 가능성이 높지만,<br>OS 업데이트 등으로 정책이 변경되면 지표가 갑자기 찍히지 않거나 이상하게 찍히는 상황이 발생할 수 있습니다.
  - 참고로 이 경우 로그인 기능이 없다면 서버를 사용하더라도, 재설치 시 IDFV 자체가 바뀌기 때문에 기존 기기와 대조할 수 있는 고유 ID가 없어서 동일 유저 추적이 불가능할거 같습니다.

## 스크린샷

`my_app_first_open` 이벤트 연동은 확인되었습니다.

| 첫실행 | 기존유저(업데이트한 사용자) | 앱 삭제 후 재설치 |
|:----:|:------:|:------:|
| <img width="252" height="330" alt="image" src="https://github.com/user-attachments/assets/45c53c1f-fd38-4532-821c-151dd8bb2fbf" /> | <img width="254" height="334" alt="image" src="https://github.com/user-attachments/assets/4a57561d-9087-4f63-8934-bbe813862992" /> | <img width="257" height="334" alt="image" src="https://github.com/user-attachments/assets/d42dabee-dd3d-4d33-a0a7-6c156ebac843" /> |

- 첫실행: `my_app_first_open` 증가
- 기존유저(업데이트한 사용자): (이전 버전이 설치되어있는 기기에서 지금 버전을 빌드했습니다.) `my_app_first_open` 증가
- 앱 삭제 후 재설치: `my_app_first_open` 변동 X

## 리뷰 요구사항
- 앱을 삭제 후 재설치해도 유지되는 ID가 있다면 알려주시면 감사하겠습니다.
- Analytics 폴더 구조 및 코드 구조가 괜찮은지 확인 부탁드립니다.
- `my_app_first_open` 앱 연동은 바로 해둘 수 있는 작업이라 포함했습니다.
- `app_opened`, `session_ended` 연동은 포함되지 않았습니다.
  - 딥링크 파라미터(entry_source, referrer_share_id) 처리와 last_screen 추적 로직이 현재 구현되지 않아 이번 PR에서는 이벤트 정의만 해뒀습니다.