### PR TITLE
키 데이터를 xcconfig 파일로 관리합니다.

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -72,6 +72,20 @@ jobs:
       run: |
         echo "🎯 사용할 시뮬레이터: ${{ steps.find-simulator.outputs.simulator_name }}"
         echo "🆔 시뮬레이터 ID: ${{ steps.find-simulator.outputs.simulator_id }}"
+
+    - name: Create xcconfig files
+      env:
+        DEBUG_XCCONFIG: ${{ secrets.DEBUG_XCCONFIG }}
+      run: |
+        CONFIG_DIR="SoloDeveloperTraining/SoloDeveloperTraining/App/Config"
+        mkdir -p "$CONFIG_DIR"
+
+        if [ -z "$DEBUG_XCCONFIG" ]; then
+          echo "❌ DEBUG_XCCONFIG secret is missing."
+          exit 1
+        fi
+
+        printf "%s" "$DEBUG_XCCONFIG" > "$CONFIG_DIR/Debug.xcconfig"
       
     - name: Cache SPM packages
       uses: actions/cache@v4

--- a/.gitignore
+++ b/.gitignore
@@ -105,10 +105,14 @@ iOSInjectionProject/
 !*.xcworkspace/contents.xcworkspacedata
 /*.gcno
 **/xcshareddata/WorkspaceSettings.xcsettings
-Secret.swift
+
 # End of https://www.toptal.com/developers/gitignore/api/swift,xcode,macos
 
 
 # Firebase
 .firebase/
 hosting.cHVibGlj.cache
+
+# .xcconfig
+SoloDeveloperTraining/SoloDeveloperTraining/App/Config/Debug.xcconfig
+SoloDeveloperTraining/SoloDeveloperTraining/App/Config/Release.xcconfig

--- a/SoloDeveloperTraining/SoloDeveloperTraining.xcodeproj/project.pbxproj
+++ b/SoloDeveloperTraining/SoloDeveloperTraining.xcodeproj/project.pbxproj
@@ -36,6 +36,8 @@
 		08267F2B2F0D06BC005A0066 /* SoloDeveloperTraining.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SoloDeveloperTraining.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		088F6A8B2FCAA7E400E14BA2 /* DUDesignSystemExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DUDesignSystemExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		2896AE422F100CD600D38732 /* SoloDeveloperTraining-Dev.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "SoloDeveloperTraining-Dev.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		B4C100012FCFE2A000000001 /* SoloDeveloperTraining/App/Config/Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = SoloDeveloperTraining/App/Config/Debug.xcconfig; sourceTree = "<group>"; };
+		B4C100022FCFE2A000000001 /* SoloDeveloperTraining/App/Config/Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = SoloDeveloperTraining/App/Config/Release.xcconfig; sourceTree = "<group>"; };
 		BCFC85392F31FED800447A9A /* SoloDeveloperTrainingTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SoloDeveloperTrainingTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -211,6 +213,7 @@
 				088F6A8C2FCAA7E400E14BA2 /* DUDesignSystemExample */,
 				BCC0EACC2F8FE90700D7A84A /* Frameworks */,
 				08267F2C2F0D06BC005A0066 /* Products */,
+				B4C100042FCFE2A000000001 /* Config */,
 				28FB154B2F9B6E3B004FCBB3 /* SoloDeveloperTraining */,
 			);
 			sourceTree = "<group>";
@@ -224,6 +227,15 @@
 				088F6A8B2FCAA7E400E14BA2 /* DUDesignSystemExample.app */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		B4C100042FCFE2A000000001 /* Config */ = {
+			isa = PBXGroup;
+			children = (
+				B4C100012FCFE2A000000001 /* SoloDeveloperTraining/App/Config/Debug.xcconfig */,
+				B4C100022FCFE2A000000001 /* SoloDeveloperTraining/App/Config/Release.xcconfig */,
+			);
+			name = Config;
 			sourceTree = "<group>";
 		};
 		BCC0EACC2F8FE90700D7A84A /* Frameworks */ = {
@@ -624,6 +636,7 @@
 		};
 		08267F372F0D06BE005A0066 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = B4C100012FCFE2A000000001 /* SoloDeveloperTraining/App/Config/Debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = app_icon_release;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -667,6 +680,7 @@
 		};
 		08267F382F0D06BE005A0066 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = B4C100022FCFE2A000000001 /* SoloDeveloperTraining/App/Config/Release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = app_icon_release;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -782,6 +796,7 @@
 		};
 		2896AE402F100CD600D38732 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = B4C100012FCFE2A000000001 /* SoloDeveloperTraining/App/Config/Debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = app_icon_dev;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -827,6 +842,7 @@
 		};
 		2896AE412F100CD600D38732 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = B4C100012FCFE2A000000001 /* SoloDeveloperTraining/App/Config/Debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = app_icon_dev;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;

--- a/SoloDeveloperTraining/SoloDeveloperTraining/App/Info-Dev.plist
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/App/Info-Dev.plist
@@ -9,14 +9,16 @@
 			<string>Editor</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>kakaod6f5c0d68a627d57b63e11bb0fd21cc8</string>
+				<string>$(KAKAO_URL_SCHEME)</string>
 			</array>
 		</dict>
 	</array>
 	<key>GADApplicationIdentifier</key>
-	<string>ca-app-pub-5929488905880864~1052005631</string>
+	<string>$(GAD_APPLICATION_IDENTIFIER)</string>
+	<key>ADMOB_INTERSTITIAL_AD_UNIT_ID</key>
+	<string>$(ADMOB_INTERSTITIAL_AD_UNIT_ID)</string>
 	<key>KAKAO_APP_KEY</key>
-	<string>d6f5c0d68a627d57b63e11bb0fd21cc8</string>
+	<string>$(KAKAO_APP_KEY)</string>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>kakaokompassauth</string>

--- a/SoloDeveloperTraining/SoloDeveloperTraining/App/Info.plist
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/App/Info.plist
@@ -15,12 +15,12 @@
 		<dict>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>kakaofb587f972d89b4cb6b50d06d9e92c03d</string>
+				<string>$(KAKAO_URL_SCHEME)</string>
 			</array>
 		</dict>
 	</array>
 	<key>KAKAO_APP_KEY</key>
-	<string>fb587f972d89b4cb6b50d06d9e92c03d</string>
+	<string>$(KAKAO_APP_KEY)</string>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>kakaokompassauth</string>
@@ -36,7 +36,9 @@
 		<string>PFStardust-ExtraBold.ttf</string>
 	</array>
 	<key>GADApplicationIdentifier</key>
-	<string>ca-app-pub-5929488905880864~1052005631</string>
+	<string>$(GAD_APPLICATION_IDENTIFIER)</string>
+	<key>ADMOB_INTERSTITIAL_AD_UNIT_ID</key>
+	<string>$(ADMOB_INTERSTITIAL_AD_UNIT_ID)</string>
 	<key>SKAdNetworkItems</key>
 	<array>
 		<dict>

--- a/SoloDeveloperTraining/SoloDeveloperTraining/App/SoloDeveloperTrainingApp.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/App/SoloDeveloperTrainingApp.swift
@@ -34,6 +34,8 @@ struct SoloDeveloperTrainingApp: App {
         MobileAds.shared.start()
         let kakaoAppKey = Bundle.main.kakaoAppKey
         KakaoSDK.initSDK(appKey: kakaoAppKey)
+        print("KAKAO_APP_KEY:", Bundle.main.kakaoAppKey)
+
     }
 
     @State private var hasSeenIntro = false

--- a/SoloDeveloperTraining/SoloDeveloperTraining/App/SoloDeveloperTrainingApp.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/App/SoloDeveloperTrainingApp.swift
@@ -34,8 +34,6 @@ struct SoloDeveloperTrainingApp: App {
         MobileAds.shared.start()
         let kakaoAppKey = Bundle.main.kakaoAppKey
         KakaoSDK.initSDK(appKey: kakaoAppKey)
-        print("KAKAO_APP_KEY:", Bundle.main.kakaoAppKey)
-
     }
 
     @State private var hasSeenIntro = false

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Extensions/Bundle+.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Extensions/Bundle+.swift
@@ -4,4 +4,8 @@ extension Bundle {
     var kakaoAppKey: String {
         return infoDictionary?["KAKAO_APP_KEY"] as? String ?? ""
     }
+
+    var adMobInterstitialAdUnitID: String {
+        return infoDictionary?["ADMOB_INTERSTITIAL_AD_UNIT_ID"] as? String ?? ""
+    }
 }

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Advertisement/InterstitialAdUnit.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Advertisement/InterstitialAdUnit.swift
@@ -12,11 +12,7 @@ final class InterstitialAdUnit: NSObject, AdUnit {
     private var resultContinuation: CheckedContinuation<Bool, Never>?
 
     var adUnitID: String {
-        #if DEBUG
-            "ca-app-pub-3940256099942544/4411468910"
-        #else
-        Secret.interstitialAdUnitID  // 실제 ID
-        #endif
+        Bundle.main.adMobInterstitialAdUnitID
     }
 
     var isReady: Bool {


### PR DESCRIPTION
## 연관된 이슈

- [KAN63](https://devvup.atlassian.net/browse/KAN-63)

## 작업 내용 및 고민 내용
### 카카오 키 및 애드몹 광고 단위 노출 제거
- 기존에 저장소에 평문으로 노출된 카카오 네이티브 키를 완전히 제거하고 새로운 키로 재발급 받았습니다.
  - 구글 키의 경우 노출된 적이 없으므로 재발급 과정은 생략했습니다.

- xcconfig 파일에 민감 키 정보를 안전하게 다루고 추후 다른 민감 키가 필요할 경우에도 대비할 수 있기 때문에 아래와 같은 키 관리 정책을 적용했습니다.
  - Debug.xcconfig: 카카오 디버그 키(공유하기 템플릿 중 테스트 메시지 전송), 구글 애드몹 광고 단위 테스트 id 포함
  - Release.xcconfig: 카카오 릴리즈 키(공유하기 실제 템플릿 메시지 전송), 구글 애드몹 광고 단위 실제 id 포함
  - .gitignore에 두 파일 추가 후 팀원 내 공유
  
- 빌드 타깃 별 xcconfig 사용 설정
  - 아래 정책에 따라 운영 타깃이 Release 모드로 빌드되는 경우를 제외하고 나머지는 모두 Debug.xcconfig 파일을 사용하도록 설정했습니다.
  
```
1. 운영 타깃 [모드에 따라 분기]
- 카카오 공유: 공유하기 링크 누르면 운영 앱 열려야함 -> 릴리즈 키 사용
- 구글 광고 노출: 릴리즈 모드는 실제 id, 디버그는 테스트 id사용 (저희 팀원 iOS 기기의 경우 테스트 기기로 등록했기 때문에 릴리즈 모드로 빌드해도 항상 테스트 id로 동작합니다.)

2. Dev 타깃 [항상 Debug 키 사용]
- 카카오 공유: 공유하기 링크 누르면 개발용 앱 열려야함 -> 디버그 키 사용
- 구글 광고 노출: 항상 테스트 id 사용
```
### 동적 환경 변수 주입
- 저장소에 파일이 업로드되지 않아 CI 환경에서 빌드가 실패하는 문제를 방지하기 위해 Github secrets에 Debug.xcconfig 파일 내용을 추가하여 CI 스크립트에서 참조할 수 있도록 수정했습니다.
- 현재 CI는 Debug 환경에서 돌아가기 때문에 Release.xcconfig 내용은 제외했습니다.

## 스크린샷
- 해당 경로와 같이 전달드린 파일 추가부탁드립니다.
<img width="267" height="111" alt="image" src="https://github.com/user-attachments/assets/70158581-34ea-4ecd-bfbf-9ed7e167e346" />

