### PR TITLE
관리자앱의 입력 유효값 규칙을 수정합니다.

### DIFF
--- a/Admin/DevUpAdmin/DevUpAdmin/Source/Models/FieldValidation.swift
+++ b/Admin/DevUpAdmin/DevUpAdmin/Source/Models/FieldValidation.swift
@@ -7,6 +7,7 @@ enum ValidationRule {
     case nonNegativeInt        // 정수, ≥ 0
     case positiveDouble        // 실수, > 0
     case nonNegativeDouble     // 실수, ≥ 0
+    case negativeDouble        // 실수, < 0
     case percent               // 실수, 0 < x ≤ 100
     case zeroToOne             // 실수, 0 < x ≤ 1 (성공률 등)
     case spawnRate             // 정수, ≥ 0 (생성률)
@@ -24,6 +25,8 @@ enum ValidationRule {
             if value <= 0  { return "0보다 큰 값이어야 합니다." }
         case .nonNegativeDouble:
             if value < 0   { return "0 이상의 값이어야 합니다." }
+        case .negativeDouble:
+            if value >= 0 { return "0보다 작은 값이어야 합니다." }
         case .percent:
             if value <= 0  { return "0보다 큰 값이어야 합니다." }
             if value > 100 { return "100 이하여야 합니다." }
@@ -43,6 +46,7 @@ enum ValidationRule {
         case .nonNegativeInt:    return "0 이상 정수"
         case .positiveDouble:    return "양수"
         case .nonNegativeDouble: return "0 이상"
+        case .negativeDouble:    return "0 미만"
         case .percent:           return "0 초과 ~ 100 이하"
         case .zeroToOne:         return "0 초과 ~ 1 이하"
         case .spawnRate:         return "0 이상 정수"
@@ -75,7 +79,7 @@ extension PolicyFieldMeta {
         rules["career.worldClassDeveloper"] = .positiveInt
 
         // 피버 기본
-        rules["fever.maxPercent"]       = .percent
+        rules["fever.maxPercent"]       = .positiveDouble
         rules["fever.decreaseInterval"] = .positiveDouble
 
         // 피버 단계 임계값 (0~100 퍼센트)
@@ -91,25 +95,25 @@ extension PolicyFieldMeta {
         rules["fever.multiplier.stage3"] = .positiveDouble
 
         // 피버 탭
-        rules["fever.tap.decreasePercent"] = .percent
+        rules["fever.tap.decreasePercent"] = .positiveDouble
         rules["fever.tap.gainPerTap"]      = .positiveDouble
 
         // 피버 언어
-        rules["fever.language.decreasePercent"]  = .percent
+        rules["fever.language.decreasePercent"]  = .positiveDouble
         rules["fever.language.gainPerCorrect"]   = .positiveDouble
-        rules["fever.language.lossPerIncorrect"] = .positiveDouble
+        rules["fever.language.lossPerIncorrect"] = .negativeDouble
 
         // 피버 닷지
-        rules["fever.dodge.decreasePercent"]  = .percent
+        rules["fever.dodge.decreasePercent"]  = .positiveDouble
         rules["fever.dodge.gainPerSmallGold"] = .positiveDouble
         rules["fever.dodge.gainPerLargeGold"] = .positiveDouble
         rules["fever.dodge.gainPerBugDodge"]  = .positiveDouble
-        rules["fever.dodge.lossPerBugHit"]    = .positiveDouble
+        rules["fever.dodge.lossPerBugHit"]    = .negativeDouble
 
         // 피버 스택
-        rules["fever.stack.decreasePercent"] = .percent
+        rules["fever.stack.decreasePercent"] = .positiveDouble
         rules["fever.stack.gainPerSuccess"]  = .positiveDouble
-        rules["fever.stack.lossPerFailure"]  = .positiveDouble
+        rules["fever.stack.lossPerFailure"]  = .negativeDouble
 
         // 게임 언어
         rules["game.language.incorrectGoldLossMultiplier"] = .positiveDouble
@@ -142,9 +146,9 @@ extension PolicyFieldMeta {
         // 스킬 레벨 범위
         rules["skill.beginnerMinLevel"]     = .positiveInt
         rules["skill.beginnerMaxLevel"]     = .positiveInt
-        rules["skill.intermediateMinLevel"] = .positiveInt
+        rules["skill.intermediateMinLevel"] = .nonNegativeInt
         rules["skill.intermediateMaxLevel"] = .positiveInt
-        rules["skill.advancedMinLevel"]     = .positiveInt
+        rules["skill.advancedMinLevel"]     = .nonNegativeInt
         rules["skill.advancedMaxLevel"]     = .positiveInt
 
         // 스킬 필드 공통 생성 함수
@@ -236,12 +240,10 @@ struct CrossFieldValidation {
             }
         }
 
-        // 스킬 레벨 범위: beginnerMax < intermediateMin < intermediateMax < advancedMin < advancedMax
+        // 스킬 레벨 범위: 각 티어 내 Min < Max
         let skillOrder: [(String, String)] = [
             ("skill.beginnerMinLevel", "skill.beginnerMaxLevel"),
-            ("skill.beginnerMaxLevel", "skill.intermediateMinLevel"),
             ("skill.intermediateMinLevel", "skill.intermediateMaxLevel"),
-            ("skill.intermediateMaxLevel", "skill.advancedMinLevel"),
             ("skill.advancedMinLevel", "skill.advancedMaxLevel"),
         ]
         let skillLabels: [String: String] = [


### PR DESCRIPTION
## 연관된 이슈

- [KAN-52](https://devvup.atlassian.net/jira/software/projects/KAN/boards/1/backlog?selectedIssue=KAN-52)

## 작업 내용 및 고민 내용

### 배경
v1.1.2 로 릴리즈된 [기존 수치](https://github.com/boostcampwm2025/iOS01-Hmm/pull/283/changes#diff-e94915998e94692ee215b1fce57855676beb8eb0063a0d7c3fb16d5e774a10af)를 관리자 앱에 입력했을 때,  
유효성 규칙이 실제 값의 범위와 맞지 않아 입력이 불가능한 문제를 수정했습니다.  

### 수정 내용

#### 1. `fever.maxPercent`
- `percent` 에서 `positiveDouble` 로 변경하였습니다.
  - 기존 규칙: 0 < x <= 100
  - 실제 값: 400

#### 2. `fever.*.decreasePercent`
- `percent`에서 `positiveDouble`로 변경하였습니다.
  - 기존 규칙: 0 < x <= 100
  - 실제 값: 1.5, 1.5, 1.2, 1.0

#### 3. `fever.*.lossPerIncorrect`
- `positiveDouble`에서 `negativeDouble`로 변경하였습니다. (신규 케이스 추가)
  - 기존 규칙: 양수만 허용
  - 실제 값: -33, -20, -40

#### 4. `skill.intermediateMinLabel`
- `positiveInt`에서 `nonNegativeInt`로 변경하였습니다.
  - 기존 규칙: x > 0
  - 실제 값: 0

#### 5. 스킬 크로스 검증 (티어 간 순서 검사 제거)
- 기존: `beginnerMax` < `intermediateMin` < `intermediateMax` < `advancedMin` < `advancedMax` 전체 순서 강제
- 실제 값: `beginnerMax = 999`, `intermediateMin = 0 `으로 티어 간 순서가 성립하지 않음

## 리뷰 요구사항
- 참고: Admin 앱으로 [기존 수치](https://github.com/boostcampwm2025/iOS01-Hmm/pull/283/changes#diff-e94915998e94692ee215b1fce57855676beb8eb0063a0d7c3fb16d5e774a10af)에 맞게 live 버전을 배포하였습니다.