### PR TITLE
성장 카테고리의 이벤트 로그를 정의합니다. (share_button_clicked, share_completed, app_opened_from_deeplink, deferred_deeplink_opened)

### DIFF
--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AnalyticsProperty.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AnalyticsProperty.swift
@@ -38,6 +38,12 @@ enum AnalyticsProperty {
     static let sessionDurationSec = "session_duration_sec"
     /// 세션 종료 전 마지막 화면
     static let lastScreen = "last_screen"
+    /// 공유 1건 식별자
+    static let shareID = "share_id"
+    /// 엔딩/결과 식별자
+    static let resultID = "result_id"
+    /// 공유 채널
+    static let shareChannel = "share_channel"
 
 }
 

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AnalyticsProperty.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AnalyticsProperty.swift
@@ -44,6 +44,8 @@ enum AnalyticsProperty {
     static let resultID = "result_id"
     /// 공유 채널
     static let shareChannel = "share_channel"
+    /// 유입을 만든 원 기기 ID
+    static let referrerDeviceID = "referrer_device_id"
 
 }
 

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AnalyticsService.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AnalyticsService.swift
@@ -77,4 +77,23 @@ final class AnalyticsService {
             AP.shareChannel: shareChannel
         ])
     }
+
+    /// 공유 완료 감지
+    func logShareCompleted(
+        shareID: String,
+        shareChannel: String,
+        resultID: String,
+        referrerShareID: String,
+        referrerDeviceID: String
+    ) {
+        Analytics.logEvent("share_completed", parameters: [
+            AP.deviceID: AP.deviceIDValue,
+            AP.sessionID: SessionManager.shared.sessionID,
+            AP.shareID: shareID,
+            AP.shareChannel: shareChannel,
+            AP.resultID: resultID,
+            AP.referrerShareID: referrerShareID,
+            AP.referrerDeviceID: referrerDeviceID
+        ])
+    }
 }

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AnalyticsService.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AnalyticsService.swift
@@ -113,4 +113,23 @@ final class AnalyticsService {
             AP.resultID: resultID
         ])
     }
+
+    /// 앱 설치 후 딥링크 유입
+    func logDeferredDeeplinkOpened(
+        entrySource: String,
+        referrerShareID: String,
+        referrerDeviceID: String,
+        isDeferredDeeplink: Bool,
+        resultID: String
+    ) {
+        Analytics.logEvent("deferred_deeplink_opened", parameters: [
+            AP.deviceID: AP.deviceIDValue,
+            AP.sessionID: SessionManager.shared.sessionID,
+            AP.entrySource: entrySource,
+            AP.referrerShareID: referrerShareID,
+            AP.referrerDeviceID: referrerDeviceID,
+            AP.isDeferredDeeplink: isDeferredDeeplink,
+            AP.resultID: resultID
+        ])
+    }
 }

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AnalyticsService.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AnalyticsService.swift
@@ -96,4 +96,21 @@ final class AnalyticsService {
             AP.referrerDeviceID: referrerDeviceID
         ])
     }
+
+    /// 딥링크로 앱 실행
+    func logAppOpenedFromDeeplink(
+        entrySource: String,
+        referrerShareID: String,
+        isDeferredDeeplink: Bool,
+        resultID: String
+    ) {
+        Analytics.logEvent("app_opened_from_deeplink", parameters: [
+            AP.deviceID: AP.deviceIDValue,
+            AP.sessionID: SessionManager.shared.sessionID,
+            AP.entrySource: entrySource,
+            AP.referrerShareID: referrerShareID,
+            AP.isDeferredDeeplink: isDeferredDeeplink,
+            AP.resultID: resultID
+        ])
+    }
 }

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AnalyticsService.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AnalyticsService.swift
@@ -60,4 +60,21 @@ final class AnalyticsService {
             AP.level: level
         ])
     }
+
+    // MARK: - 공유
+
+    /// 공유 버튼 클릭
+    func logShareButtonClicked(
+        shareID: String,
+        resultID: String,
+        shareChannel: String
+    ) {
+        Analytics.logEvent("share_button_clicked", parameters: [
+            AP.deviceID: AP.deviceIDValue,
+            AP.sessionID: SessionManager.shared.sessionID,
+            AP.shareID: shareID,
+            AP.resultID: resultID,
+            AP.shareChannel: shareChannel
+        ])
+    }
 }


### PR DESCRIPTION
## 연관된 이슈

- [KAN-87](https://devvup.atlassian.net/jira/software/projects/KAN/boards/1/backlog?selectedIssue=KAN-87)
  - [KAN-103 (share_button_clicked)](https://devvup.atlassian.net/browse/KAN-103)
  - [KAN-104 (share_completed)](https://devvup.atlassian.net/browse/KAN-104)
  - [KAN-105 (app_opened_from_deeplink)](https://devvup.atlassian.net/browse/KAN-105)
  - [KAN-106 (deferred_deeplink_opened)](https://devvup.atlassian.net/browse/KAN-106)

## 작업 내용 및 고민 내용

### 공유 카테고리 이벤트 4개 정의 완료

| 이벤트 | 속성 |
| -- | -- |
| share_button_clicked | device_id, session_id, share_id, result_id, share_channel |
| share_completed | device_id, session_id, share_id, share_channel, result_id, referrer_share_id, referrer_device_id |
| app_opened_from_deeplink | device_id, session_id, entry_source, referrer_share_id, is_deferred_deeplink, result_id
| deferred_deeplink_opened | device_id, session_id, entry_source, referrer_share_id, referrer_device_id, is_deferred_deeplink, result_id | 

### 추후 연결 시 고려되는 작업 목록

#### share_button_clicked
- 연결 위치: 공유 화면에서 각 채널 버튼 탭 시점
- share_id는 공유 화면 진입 시점에 UUID().uuidString으로 생성해서 각 채널 버튼과 공유
- result_id는 공유 화면에 Ending 또는 resultID: String을 파라미터로 주입
- share_channel은 각 버튼에 맞는 허용값 사용 (허용값: kakao, instagram, x, facebook, os_share, copy_link, unknown)

#### share_completed

- share_id, share_channel은 share_button_clicked와 동일한 값 사용
- referrer_share_id, referrer_device_id는 딥링크 구현 선행 필요
- 딥링크 구현 완료 후 연결 가능

#### app_opened_from_deeplink

- 딥링크 파라미터를 가진 앱 오픈 수신 시 발생
- onOpenURL에서 URL 파싱 로직 구현 필요
- 공유 링크 포맷에 share_id 등 파라미터 포함하는 설계 필요
- 딥링크 구현 완료 후 연결 가능

#### deferred_deeplink_opened

- 미설치 사용자가 설치 후 딥링크 파라미터로 최초 실행 시 발생
- Firebase Dynamic Links 등 별도 솔루션 도입 필요
- 딥링크 구현 완료 후 연결 가능

## 리뷰 요구사항

- 해당 이슈로 이동하면, 현황 및 이벤트 연결 시 필요한 작업을 고민하여 정리해두었습니다.