### PR TITLE
광고 관련 이벤트를 정의합니다. (우선순위 urgent, high)

### DIFF
--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Advertisement/AdService.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Advertisement/AdService.swift
@@ -11,30 +11,6 @@ enum AdType: String {
     case interstitial
 }
 
-enum AdPlacementType: String {
-    case consumable
-    case workExit
-    case equipmentEnhance
-    case reselectionReward
-    case skillReward
-    case quizReward
-    case offlineReward
-}
-
-enum AdRewardType: String {
-    case gold
-    case diamond
-    case coffee
-    case energyDrink
-    case reselect
-}
-
-enum AdOfferDismissReasonType: String {
-    case close
-    case background
-    case unknown
-}
-
 @MainActor
 final class AdService {
     static let shared: AdService = {

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Advertisement/AdService.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Advertisement/AdService.swift
@@ -29,6 +29,12 @@ enum AdRewardType: String {
     case reselect
 }
 
+enum AdOfferDismissReasonType: String {
+    case close
+    case background
+    case unknown
+}
+
 @MainActor
 final class AdService {
     static let shared: AdService = {

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Advertisement/AdService.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Advertisement/AdService.swift
@@ -11,6 +11,16 @@ enum AdType {
     case interstitial
 }
 
+enum AdPlacementType {
+    case consumable
+    case workExit
+    case equipmentEnhance
+    case reselectionReward
+    case skillReward
+    case quizReward
+    case offlineReward
+}
+
 @MainActor
 final class AdService {
     static let shared: AdService = {

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Advertisement/AdService.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Advertisement/AdService.swift
@@ -7,11 +7,11 @@
 
 import AppTrackingTransparency
 
-enum AdType {
+enum AdType: String {
     case interstitial
 }
 
-enum AdPlacementType {
+enum AdPlacementType: String {
     case consumable
     case workExit
     case equipmentEnhance
@@ -19,6 +19,14 @@ enum AdPlacementType {
     case skillReward
     case quizReward
     case offlineReward
+}
+
+enum AdRewardType: String {
+    case gold
+    case diamond
+    case coffee
+    case energyDrink
+    case reselect
 }
 
 @MainActor

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AdAnalyticsSchema.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AdAnalyticsSchema.swift
@@ -1,0 +1,30 @@
+//
+//  AdAnalyticsSchema.swift
+//  SoloDeveloperTraining
+//
+//  Created by sunjae on 6/4/26.
+//
+
+enum AdPlacementType: String {
+    case consumable
+    case workExit
+    case equipmentEnhance
+    case reselectionReward
+    case skillReward
+    case quizReward
+    case offlineReward
+}
+
+enum AdRewardType: String {
+    case gold
+    case diamond
+    case coffee
+    case energyDrink
+    case reselect
+}
+
+enum AdOfferDismissReasonType: String {
+    case close
+    case background
+    case unknown
+}

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AdAnalyticsSchema.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AdAnalyticsSchema.swift
@@ -5,6 +5,14 @@
 //  Created by sunjae on 6/4/26.
 //
 
+enum AdAnalyticsEvent: String {
+    case offerViewed = "ad_offer_viewed"
+    case watchClicked = "ad_watch_clicked"
+    case watchCompleted = "ad_watch_completed"
+    case rewardClaimed = "ad_reward_claimed"
+    case offerDismissed = "ad_offer_dismissed"
+}
+
 enum AdPlacementType: String {
     case consumable
     case workExit

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AnalyticsProperty.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AnalyticsProperty.swift
@@ -54,6 +54,8 @@ enum AnalyticsProperty {
     static let adNetwork = "ad_network"
     /// 광고 유닛 ID
     static let adUnitID = "ad_unit_id"
+    /// 광고 시청 시간
+    static let adWatchDurationSec = "ad_watch_duration_sec"
 
 }
 

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AnalyticsProperty.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AnalyticsProperty.swift
@@ -39,6 +39,22 @@ enum AnalyticsProperty {
     /// 세션 종료 전 마지막 화면
     static let lastScreen = "last_screen"
 
+    // MARK: - 광고 관련 프로퍼티
+    /// 광고 보상 플로우 식별자
+    static let adRewardFlowID = "ad_reward_flow_id"
+    /// 광고 제안 위치
+    static let adPlacement = "ad_placement"
+    /// 광고 보상 종류
+    static let rewardType = "reward_type"
+    /// 광고 보상량
+    static let rewardAmount = "reward_amount"
+    /// 광고 형식
+    static let adFormat = "ad_format"
+    /// 광고 네트워크
+    static let adNetwork = "ad_network"
+    /// 광고 유닛 ID
+    static let adUnitID = "ad_unit_id"
+
 }
 
 // MARK: - Device Values

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AnalyticsProperty.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AnalyticsProperty.swift
@@ -54,6 +54,8 @@ enum AnalyticsProperty {
     static let adNetwork = "ad_network"
     /// 광고 유닛 ID
     static let adUnitID = "ad_unit_id"
+    /// 광고 제안 거절/닫기 사유
+    static let dismissReason = "dismiss_reason"
     /// 광고 시청 시간
     static let adWatchDurationSec = "ad_watch_duration_sec"
 

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AnalyticsService.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AnalyticsService.swift
@@ -94,17 +94,17 @@ extension AnalyticsService {
     func logAdWatchClicked(
         adRewardFlowID: String,
         adPlacement: AdPlacementType,
-        rewardType: String,
+        rewardType: AdRewardType,
         rewardAmount: Int
     ) {
         Analytics.logEvent("ad_watch_clicked", parameters: [
             AP.deviceID: AP.deviceIDValue,
             AP.sessionID: SessionManager.shared.sessionID,
             AP.adRewardFlowID: adRewardFlowID,
-            AP.adPlacement: adPlacement,
-            AP.rewardType: rewardType,
+            AP.adPlacement: adPlacement.rawValue,
+            AP.rewardType: rewardType.rawValue,
             AP.rewardAmount: rewardAmount,
-            AP.adFormat: AdType.interstitial,
+            AP.adFormat: AdType.interstitial.rawValue,
             AP.adNetwork: "admob",
             AP.adUnitID: Bundle.main.adMobInterstitialAdUnitID
         ])
@@ -114,7 +114,7 @@ extension AnalyticsService {
     func logAdWatchCompleted(
         adRewardFlowID: String,
         adPlacement: AdPlacementType,
-        rewardType: String,
+        rewardType: AdRewardType,
         rewardAmount: Int,
         adWatchDurationSec: Int
     ) {
@@ -122,13 +122,33 @@ extension AnalyticsService {
             AP.deviceID: AP.deviceIDValue,
             AP.sessionID: SessionManager.shared.sessionID,
             AP.adRewardFlowID: adRewardFlowID,
-            AP.adPlacement: adPlacement,
-            AP.rewardType: rewardType,
+            AP.adPlacement: adPlacement.rawValue,
+            AP.rewardType: rewardType.rawValue,
             AP.rewardAmount: rewardAmount,
-            AP.adFormat: AdType.interstitial,
+            AP.adFormat: AdType.interstitial.rawValue,
             AP.adNetwork: "admob",
             AP.adUnitID: Bundle.main.adMobInterstitialAdUnitID,
             AP.adWatchDurationSec: adWatchDurationSec
+        ])
+    }
+
+    /// 광고 완료 후 보상이 실제 지급 완료될 때
+    func logAdRewardClaimed(
+        adRewardFlowID: String,
+        adPlacement: AdPlacementType,
+        rewardType: AdRewardType,
+        rewardAmount: Int
+    ) {
+        Analytics.logEvent("ad_reward_claimed", parameters: [
+            AP.deviceID: AP.deviceIDValue,
+            AP.sessionID: SessionManager.shared.sessionID,
+            AP.adRewardFlowID: adRewardFlowID,
+            AP.adPlacement: adPlacement.rawValue,
+            AP.rewardType: rewardType.rawValue,
+            AP.rewardAmount: rewardAmount,
+            AP.adFormat: AdType.interstitial.rawValue,
+            AP.adNetwork: "admob",
+            AP.adUnitID: Bundle.main.adMobInterstitialAdUnitID,
         ])
     }
 }

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AnalyticsService.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AnalyticsService.swift
@@ -12,6 +12,9 @@ private typealias AP = AnalyticsProperty
 final class AnalyticsService {
     static let shared = AnalyticsService()
 
+    /// 광고 이벤트별 flow ID 중복 로깅 방지
+    private var loggedAdRewardFlowIDsByEvent: [AdAnalyticsEvent: Set<String>] = [:]
+
     private init() {}
 
     // MARK: - 성장
@@ -77,7 +80,10 @@ extension AnalyticsService {
         rewardType: AdRewardType,
         rewardAmount: Int
     ) {
-        Analytics.logEvent("ad_offer_viewed", parameters: [
+        let event = AdAnalyticsEvent.offerViewed
+        guard shouldLogAdEvent(event, adRewardFlowID: adRewardFlowID) else { return }
+
+        Analytics.logEvent(event.rawValue, parameters: [
             AP.deviceID: AP.deviceIDValue,
             AP.sessionID: SessionManager.shared.sessionID,
             AP.adRewardFlowID: adRewardFlowID,
@@ -97,7 +103,10 @@ extension AnalyticsService {
         rewardType: AdRewardType,
         rewardAmount: Int
     ) {
-        Analytics.logEvent("ad_watch_clicked", parameters: [
+        let event = AdAnalyticsEvent.watchClicked
+        guard shouldLogAdEvent(event, adRewardFlowID: adRewardFlowID) else { return }
+
+        Analytics.logEvent(event.rawValue, parameters: [
             AP.deviceID: AP.deviceIDValue,
             AP.sessionID: SessionManager.shared.sessionID,
             AP.adRewardFlowID: adRewardFlowID,
@@ -118,7 +127,10 @@ extension AnalyticsService {
         rewardAmount: Int,
         adWatchDurationSec: Int
     ) {
-        Analytics.logEvent("ad_watch_completed", parameters: [
+        let event = AdAnalyticsEvent.watchCompleted
+        guard shouldLogAdEvent(event, adRewardFlowID: adRewardFlowID) else { return }
+
+        Analytics.logEvent(event.rawValue, parameters: [
             AP.deviceID: AP.deviceIDValue,
             AP.sessionID: SessionManager.shared.sessionID,
             AP.adRewardFlowID: adRewardFlowID,
@@ -139,7 +151,10 @@ extension AnalyticsService {
         rewardType: AdRewardType,
         rewardAmount: Int
     ) {
-        Analytics.logEvent("ad_reward_claimed", parameters: [
+        let event = AdAnalyticsEvent.rewardClaimed
+        guard shouldLogAdEvent(event, adRewardFlowID: adRewardFlowID) else { return }
+
+        Analytics.logEvent(event.rawValue, parameters: [
             AP.deviceID: AP.deviceIDValue,
             AP.sessionID: SessionManager.shared.sessionID,
             AP.adRewardFlowID: adRewardFlowID,
@@ -160,7 +175,10 @@ extension AnalyticsService {
         rewardAmount: Int,
         dismissReason: AdOfferDismissReasonType
     ) {
-        Analytics.logEvent("ad_offer_dismissed", parameters: [
+        let event = AdAnalyticsEvent.offerDismissed
+        guard shouldLogAdEvent(event, adRewardFlowID: adRewardFlowID) else { return }
+
+        Analytics.logEvent(event.rawValue, parameters: [
             AP.deviceID: AP.deviceIDValue,
             AP.sessionID: SessionManager.shared.sessionID,
             AP.adRewardFlowID: adRewardFlowID,
@@ -169,5 +187,12 @@ extension AnalyticsService {
             AP.rewardAmount: rewardAmount,
             AP.dismissReason: dismissReason.rawValue
         ])
+    }
+
+    private func shouldLogAdEvent(_ event: AdAnalyticsEvent, adRewardFlowID: String) -> Bool {
+        var loggedFlowIDs = loggedAdRewardFlowIDsByEvent[event, default: []]
+        guard loggedFlowIDs.insert(adRewardFlowID).inserted else { return false }
+        loggedAdRewardFlowIDsByEvent[event] = loggedFlowIDs
+        return true
     }
 }

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AnalyticsService.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AnalyticsService.swift
@@ -12,6 +12,8 @@ private typealias AP = AnalyticsProperty
 final class AnalyticsService {
     static let shared = AnalyticsService()
 
+    private var loggedAdOfferFlowIDs: Set<String> = []
+
     private init() {}
 
     // MARK: - 성장
@@ -58,6 +60,33 @@ final class AnalyticsService {
             AP.sessionDurationSec: SessionManager.shared.sessionDurationSec,
             AP.lastScreen: lastScreen,
             AP.level: level
+        ])
+    }
+}
+
+// MARK: - 광고
+extension AnalyticsService {
+
+    /// 광고 보기 버튼/팝업이 사용자에게 노출될 때
+    func logAdOfferViewed(
+        adPlacement: AdPlacementType,
+        rewardType: String,
+        rewardAmount: Int
+    ) {
+        let adRewardFlowID = "ad_flow_\(UUID())"
+        guard !loggedAdOfferFlowIDs.contains(adRewardFlowID) else { return }
+        loggedAdOfferFlowIDs.insert(adRewardFlowID)
+
+        Analytics.logEvent("ad_offer_viewed", parameters: [
+            AP.deviceID: AP.deviceIDValue,
+            AP.sessionID: SessionManager.shared.sessionID,
+            AP.adRewardFlowID: adRewardFlowID,
+            AP.adPlacement: adPlacement,
+            AP.rewardType: rewardType,
+            AP.rewardAmount: rewardAmount,
+            AP.adFormat: AdType.interstitial,
+            AP.adNetwork: "admob",
+            AP.adUnitID: Bundle.main.adMobInterstitialAdUnitID
         ])
     }
 }

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AnalyticsService.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AnalyticsService.swift
@@ -12,8 +12,6 @@ private typealias AP = AnalyticsProperty
 final class AnalyticsService {
     static let shared = AnalyticsService()
 
-    private var loggedAdOfferFlowIDs: Set<String> = []
-
     private init() {}
 
     // MARK: - 성장
@@ -67,17 +65,39 @@ final class AnalyticsService {
 // MARK: - 광고
 extension AnalyticsService {
 
+    /// 광고 흐름 (광고 제안 → 클릭 → 시작 → 완료 → 보상) 식별자 생성
+    func makeAdRewardFlowID() -> String {
+        "ad_reward_\(UUID().uuidString)"
+    }
+
     /// 광고 보기 버튼/팝업이 사용자에게 노출될 때
     func logAdOfferViewed(
+        adRewardFlowID: String,
+        adPlacement: AdPlacementType,
+        rewardType: AdRewardType,
+        rewardAmount: Int
+    ) {
+        Analytics.logEvent("ad_offer_viewed", parameters: [
+            AP.deviceID: AP.deviceIDValue,
+            AP.sessionID: SessionManager.shared.sessionID,
+            AP.adRewardFlowID: adRewardFlowID,
+            AP.adPlacement: adPlacement.rawValue,
+            AP.rewardType: rewardType.rawValue,
+            AP.rewardAmount: rewardAmount,
+            AP.adFormat: AdType.interstitial.rawValue,
+            AP.adNetwork: "admob",
+            AP.adUnitID: Bundle.main.adMobInterstitialAdUnitID
+        ])
+    }
+
+    /// 광고 보기를 클릭했을 때
+    func logAdWatchClicked(
+        adRewardFlowID: String,
         adPlacement: AdPlacementType,
         rewardType: String,
         rewardAmount: Int
     ) {
-        let adRewardFlowID = "ad_flow_\(UUID())"
-        guard !loggedAdOfferFlowIDs.contains(adRewardFlowID) else { return }
-        loggedAdOfferFlowIDs.insert(adRewardFlowID)
-
-        Analytics.logEvent("ad_offer_viewed", parameters: [
+        Analytics.logEvent("ad_watch_clicked", parameters: [
             AP.deviceID: AP.deviceIDValue,
             AP.sessionID: SessionManager.shared.sessionID,
             AP.adRewardFlowID: adRewardFlowID,

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AnalyticsService.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AnalyticsService.swift
@@ -151,4 +151,23 @@ extension AnalyticsService {
             AP.adUnitID: Bundle.main.adMobInterstitialAdUnitID,
         ])
     }
+
+    /// 사용자가 광고 제안을 닫거나 보지 않기로 선택 시
+    func logAdOfferDismissed(
+        adRewardFlowID: String,
+        adPlacement: AdPlacementType,
+        rewardType: AdRewardType,
+        rewardAmount: Int,
+        dismissReason: AdOfferDismissReasonType
+    ) {
+        Analytics.logEvent("ad_offer_dismissed", parameters: [
+            AP.deviceID: AP.deviceIDValue,
+            AP.sessionID: SessionManager.shared.sessionID,
+            AP.adRewardFlowID: adRewardFlowID,
+            AP.adPlacement: adPlacement.rawValue,
+            AP.rewardType: rewardType.rawValue,
+            AP.rewardAmount: rewardAmount,
+            AP.dismissReason: dismissReason.rawValue
+        ])
+    }
 }

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AnalyticsService.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AnalyticsService.swift
@@ -80,20 +80,13 @@ extension AnalyticsService {
         rewardType: AdRewardType,
         rewardAmount: Int
     ) {
-        let event = AdAnalyticsEvent.offerViewed
-        guard shouldLogAdEvent(event, adRewardFlowID: adRewardFlowID) else { return }
-
-        Analytics.logEvent(event.rawValue, parameters: [
-            AP.deviceID: AP.deviceIDValue,
-            AP.sessionID: SessionManager.shared.sessionID,
-            AP.adRewardFlowID: adRewardFlowID,
-            AP.adPlacement: adPlacement.rawValue,
-            AP.rewardType: rewardType.rawValue,
-            AP.rewardAmount: rewardAmount,
-            AP.adFormat: AdType.interstitial.rawValue,
-            AP.adNetwork: "admob",
-            AP.adUnitID: Bundle.main.adMobInterstitialAdUnitID
-        ])
+        logAdEvent(
+            .offerViewed,
+            adRewardFlowID: adRewardFlowID,
+            adPlacement: adPlacement,
+            rewardType: rewardType,
+            rewardAmount: rewardAmount
+        )
     }
 
     /// 광고 보기를 클릭했을 때
@@ -103,20 +96,13 @@ extension AnalyticsService {
         rewardType: AdRewardType,
         rewardAmount: Int
     ) {
-        let event = AdAnalyticsEvent.watchClicked
-        guard shouldLogAdEvent(event, adRewardFlowID: adRewardFlowID) else { return }
-
-        Analytics.logEvent(event.rawValue, parameters: [
-            AP.deviceID: AP.deviceIDValue,
-            AP.sessionID: SessionManager.shared.sessionID,
-            AP.adRewardFlowID: adRewardFlowID,
-            AP.adPlacement: adPlacement.rawValue,
-            AP.rewardType: rewardType.rawValue,
-            AP.rewardAmount: rewardAmount,
-            AP.adFormat: AdType.interstitial.rawValue,
-            AP.adNetwork: "admob",
-            AP.adUnitID: Bundle.main.adMobInterstitialAdUnitID
-        ])
+        logAdEvent(
+            .watchClicked,
+            adRewardFlowID: adRewardFlowID,
+            adPlacement: adPlacement,
+            rewardType: rewardType,
+            rewardAmount: rewardAmount
+        )
     }
 
     /// 광고 시청을 완료했을 때
@@ -127,21 +113,16 @@ extension AnalyticsService {
         rewardAmount: Int,
         adWatchDurationSec: Int
     ) {
-        let event = AdAnalyticsEvent.watchCompleted
-        guard shouldLogAdEvent(event, adRewardFlowID: adRewardFlowID) else { return }
-
-        Analytics.logEvent(event.rawValue, parameters: [
-            AP.deviceID: AP.deviceIDValue,
-            AP.sessionID: SessionManager.shared.sessionID,
-            AP.adRewardFlowID: adRewardFlowID,
-            AP.adPlacement: adPlacement.rawValue,
-            AP.rewardType: rewardType.rawValue,
-            AP.rewardAmount: rewardAmount,
-            AP.adFormat: AdType.interstitial.rawValue,
-            AP.adNetwork: "admob",
-            AP.adUnitID: Bundle.main.adMobInterstitialAdUnitID,
-            AP.adWatchDurationSec: adWatchDurationSec
-        ])
+        logAdEvent(
+            .watchCompleted,
+            adRewardFlowID: adRewardFlowID,
+            adPlacement: adPlacement,
+            rewardType: rewardType,
+            rewardAmount: rewardAmount,
+            additionalParameters: [
+                AP.adWatchDurationSec: adWatchDurationSec
+            ]
+        )
     }
 
     /// 광고 완료 후 보상이 실제 지급 완료될 때
@@ -151,20 +132,13 @@ extension AnalyticsService {
         rewardType: AdRewardType,
         rewardAmount: Int
     ) {
-        let event = AdAnalyticsEvent.rewardClaimed
-        guard shouldLogAdEvent(event, adRewardFlowID: adRewardFlowID) else { return }
-
-        Analytics.logEvent(event.rawValue, parameters: [
-            AP.deviceID: AP.deviceIDValue,
-            AP.sessionID: SessionManager.shared.sessionID,
-            AP.adRewardFlowID: adRewardFlowID,
-            AP.adPlacement: adPlacement.rawValue,
-            AP.rewardType: rewardType.rawValue,
-            AP.rewardAmount: rewardAmount,
-            AP.adFormat: AdType.interstitial.rawValue,
-            AP.adNetwork: "admob",
-            AP.adUnitID: Bundle.main.adMobInterstitialAdUnitID,
-        ])
+        logAdEvent(
+            .rewardClaimed,
+            adRewardFlowID: adRewardFlowID,
+            adPlacement: adPlacement,
+            rewardType: rewardType,
+            rewardAmount: rewardAmount
+        )
     }
 
     /// 사용자가 광고 제안을 닫거나 보지 않기로 선택 시
@@ -175,21 +149,66 @@ extension AnalyticsService {
         rewardAmount: Int,
         dismissReason: AdOfferDismissReasonType
     ) {
-        let event = AdAnalyticsEvent.offerDismissed
-        guard shouldLogAdEvent(event, adRewardFlowID: adRewardFlowID) else { return }
+        logAdEvent(
+            .offerDismissed,
+            adRewardFlowID: adRewardFlowID,
+            adPlacement: adPlacement,
+            rewardType: rewardType,
+            rewardAmount: rewardAmount,
+            includesAdInfo: false,
+            additionalParameters: [
+                AP.dismissReason: dismissReason.rawValue
+            ]
+        )
+    }
 
-        Analytics.logEvent(event.rawValue, parameters: [
+    private func logAdEvent(
+        _ event: AdAnalyticsEvent,
+        adRewardFlowID: String,
+        adPlacement: AdPlacementType,
+        rewardType: AdRewardType? = nil,
+        rewardAmount: Int? = nil,
+        includesReward: Bool = true,
+        includesAdInfo: Bool = true,
+        additionalParameters: [String: Any] = [:]
+    ) {
+        guard registerAdEventOnce(event, adRewardFlowID: adRewardFlowID) else { return }
+
+        var parameters = baseAdEventParameters(
+            adRewardFlowID: adRewardFlowID,
+            adPlacement: adPlacement,
+            includesAdInfo: includesAdInfo
+        )
+        if includesReward, let rewardType, let rewardAmount {
+            parameters[AP.rewardType] = rewardType.rawValue
+            parameters[AP.rewardAmount] = rewardAmount
+        }
+        additionalParameters.forEach { parameters[$0.key] = $0.value }
+
+        Analytics.logEvent(event.rawValue, parameters: parameters)
+    }
+
+    private func baseAdEventParameters(
+        adRewardFlowID: String,
+        adPlacement: AdPlacementType,
+        includesAdInfo: Bool
+    ) -> [String: Any] {
+        var parameters: [String: Any] = [
             AP.deviceID: AP.deviceIDValue,
             AP.sessionID: SessionManager.shared.sessionID,
             AP.adRewardFlowID: adRewardFlowID,
-            AP.adPlacement: adPlacement.rawValue,
-            AP.rewardType: rewardType.rawValue,
-            AP.rewardAmount: rewardAmount,
-            AP.dismissReason: dismissReason.rawValue
-        ])
+            AP.adPlacement: adPlacement.rawValue
+        ]
+
+        if includesAdInfo {
+            parameters[AP.adFormat] = AdType.interstitial.rawValue
+            parameters[AP.adNetwork] = "admob"
+            parameters[AP.adUnitID] = Bundle.main.adMobInterstitialAdUnitID
+        }
+        return parameters
     }
 
-    private func shouldLogAdEvent(_ event: AdAnalyticsEvent, adRewardFlowID: String) -> Bool {
+    private func registerAdEventOnce(_ event: AdAnalyticsEvent, adRewardFlowID: String) -> Bool {
         var loggedFlowIDs = loggedAdRewardFlowIDsByEvent[event, default: []]
         guard loggedFlowIDs.insert(adRewardFlowID).inserted else { return false }
         loggedAdRewardFlowIDsByEvent[event] = loggedFlowIDs

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AnalyticsService.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AnalyticsService.swift
@@ -109,4 +109,26 @@ extension AnalyticsService {
             AP.adUnitID: Bundle.main.adMobInterstitialAdUnitID
         ])
     }
+
+    /// 광고 시청을 완료했을 때
+    func logAdWatchCompleted(
+        adRewardFlowID: String,
+        adPlacement: AdPlacementType,
+        rewardType: String,
+        rewardAmount: Int,
+        adWatchDurationSec: Int
+    ) {
+        Analytics.logEvent("ad_watch_completed", parameters: [
+            AP.deviceID: AP.deviceIDValue,
+            AP.sessionID: SessionManager.shared.sessionID,
+            AP.adRewardFlowID: adRewardFlowID,
+            AP.adPlacement: adPlacement,
+            AP.rewardType: rewardType,
+            AP.rewardAmount: rewardAmount,
+            AP.adFormat: AdType.interstitial,
+            AP.adNetwork: "admob",
+            AP.adUnitID: Bundle.main.adMobInterstitialAdUnitID,
+            AP.adWatchDurationSec: adWatchDurationSec
+        ])
+    }
 }


### PR DESCRIPTION
## 연관된 이슈

- [KAN-88](https://devvup.atlassian.net/browse/KAN-88)

## 작업 내용 및 고민 내용
### 광고 단위 흐름에 대한 세션 ID 정의
- 기획서상 광고 이벤트의 경우, 여러 이벤트들이 순서를 가지고 하나의 흐름을 구성하고 있어 하나의 흐름을 '세션'으로 정의했으며, 세션을  UUID로 식별했습니다.
- 또한 기획서상 현재 작업 범위에 포함된 이벤트들은 모두 '세션 당 1회' 기준으로 잡혀있어, 한 흐름을 구성하는 이벤트로서`AdAnalyticsEvent` 열거형 타입 내에 케이스로 정의했습니다.

### 추가된 이벤트 프로퍼티
- 프로퍼티의 경우 모든 프로퍼티가 아닌 현재 작업 범위에서 필요한 프로퍼티에 한해 선언했으며, 이벤트 로그 정의서의 '상태' 컬럼 또한 업데이트 했습니다. 추가된 프로퍼티는 아래와 같습니다.
```swift
    /// 광고 보상 플로우 식별자
    static let adRewardFlowID = "ad_reward_flow_id"
    /// 광고 제안 위치
    static let adPlacement = "ad_placement"
    /// 광고 보상 종류
    static let rewardType = "reward_type"
    /// 광고 보상량
    static let rewardAmount = "reward_amount"
    /// 광고 형식
    static let adFormat = "ad_format"
    /// 광고 네트워크
    static let adNetwork = "ad_network"
    /// 광고 유닛 ID
    static let adUnitID = "ad_unit_id"
    /// 광고 제안 거절/닫기 사유
    static let dismissReason = "dismiss_reason"
    /// 광고 시청 시간
    static let adWatchDurationSec = "ad_watch_duration_sec"
```

### 중복 프로퍼티를 가지는 메서드 공통화
- 모든 이벤트들이 중복되는 여러 개의 파라미터를 가지고 있어 중복되는 코드가 늘어나, 필요한 공통 파라미터들을 추가하고 경우에 따라 필요한 파라미터를 추가해주는 `logAdEvent` 메서드를 구현했습니다.
- 모든 광고 이벤트 로깅 함수들은 해당 함수를 호출하는 형태입니다.

### 광고 이벤트별 flow 중복 로깅 방지
- 하나의 세션에 대한 식별자를 UUID로 생성하고 logAdEvent 메서드 내부에서 registerAdEventOnce 메소드를 호출하여 특정 이벤트에 대해 이미 등록된 Id가 존재할 경우 그대로 함수를 종료하여 같은 세션 내에서 중복 이벤트가 발생하지 않도록 구현했습니다.
