### PR TITLE
디자인 시스템 컴포넌트를 구현합니다.

### DIFF
--- a/DUDesignSystem/Sources/DUDesignSystem/Components/Bars/GameToolBar.swift
+++ b/DUDesignSystem/Sources/DUDesignSystem/Components/Bars/GameToolBar.swift
@@ -1,0 +1,127 @@
+//
+//  GameToolBar.swift
+//  DUDesignSystem
+//
+//  Created by SeoJunYoung on 6/7/26.
+//
+
+import SwiftUI
+
+public struct GameToolBar: View {
+
+    /// 피버 단계 (0~3)
+    public var feverStage: Int
+    /// 현재 단계 내 진행도 (0.0 ~ 1.0)
+    public var feverProgress: Double
+    /// 피버 배수 텍스트 (0이면 미표시)
+    public var feverMultiplier: Double
+    /// 커피 보유 개수
+    public var coffeeCount: Int
+    /// 에너지드링크 보유 개수
+    public var energyDrinkCount: Int
+
+    public var onClose: () -> Void
+    public var onCoffee: () -> Void
+    public var onEnergyDrink: () -> Void
+
+    public init(
+        feverStage: Int,
+        feverProgress: Double,
+        feverMultiplier: Double = 0,
+        coffeeCount: Int,
+        energyDrinkCount: Int,
+        onClose: @escaping () -> Void,
+        onCoffee: @escaping () -> Void,
+        onEnergyDrink: @escaping () -> Void
+    ) {
+        self.feverStage = feverStage
+        self.feverProgress = max(0, min(1, feverProgress))
+        self.feverMultiplier = feverMultiplier
+        self.coffeeCount = coffeeCount
+        self.energyDrinkCount = energyDrinkCount
+        self.onClose = onClose
+        self.onCoffee = onCoffee
+        self.onEnergyDrink = onEnergyDrink
+    }
+
+    private var fillColor: Color {
+        switch feverStage {
+        case 0: return Color.gray400
+        case 1: return Color.accentYellow
+        case 2: return Color.lightOrange
+        case 3: return Color.accentRed
+        default: return Color.gray400
+        }
+    }
+
+    private var backgroundColor: Color {
+        switch feverStage {
+        case 0: return Color.black300GrayBar
+        case 1: return Color.gray400
+        case 2: return Color.accentYellow
+        case 3: return Color.lightOrange
+        default: return Color.black300GrayBar
+        }
+    }
+
+    public var body: some View {
+        HStack(spacing: TokenSpacing.sm) {
+            Button(action: onClose) {
+                DUIcon(.close, size: .size24)
+            }
+
+            feverBar
+
+            HStack(spacing: TokenSpacing.sm) {
+                itemButton(icon: .coffee, count: coffeeCount, action: onCoffee)
+                itemButton(icon: .energyDrink, count: energyDrinkCount, action: onEnergyDrink)
+            }
+        }
+        .padding(.horizontal, TokenSpacing.md)
+    }
+
+    private var feverBar: some View {
+        GeometryReader { geo in
+            ZStack {
+                RoundedRectangle(cornerRadius: TokenRadius.ss)
+                    .fill(backgroundColor)
+                    .frame(height: 16)
+
+                RoundedRectangle(cornerRadius: TokenRadius.ss)
+                    .fill(fillColor)
+                    .frame(width: geo.size.width * feverProgress, height: 16)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                if feverMultiplier > 0 {
+                    Text(String(format: "Fever %.1fx !!", feverMultiplier))
+                        .duFont(.caption)
+                        .foregroundStyle(Color.white300)
+                }
+            }
+        }
+        .frame(height: 16)
+    }
+
+    private func itemButton(icon: DUIconName, count: Int, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            HStack(spacing: TokenSpacing.xs) {
+                DUIcon(icon, size: .size24)
+                Text("\(count)")
+                    .duFont(.caption)
+                    .foregroundStyle(Color.black300)
+            }
+        }
+    }
+}
+
+#Preview {
+    VStack(spacing: TokenSpacing.lg) {
+        GameToolBar(feverStage: 0, feverProgress: 0, coffeeCount: 999, energyDrinkCount: 999, onClose: {}, onCoffee: {}, onEnergyDrink: {})
+        GameToolBar(feverStage: 0, feverProgress: 0.5, coffeeCount: 999, energyDrinkCount: 999, onClose: {}, onCoffee: {}, onEnergyDrink: {})
+        GameToolBar(feverStage: 1, feverProgress: 0.8, feverMultiplier: 0.8, coffeeCount: 999, energyDrinkCount: 999, onClose: {}, onCoffee: {}, onEnergyDrink: {})
+        GameToolBar(feverStage: 2, feverProgress: 0.5, feverMultiplier: 2.0, coffeeCount: 999, energyDrinkCount: 999, onClose: {}, onCoffee: {}, onEnergyDrink: {})
+        GameToolBar(feverStage: 3, feverProgress: 0.3, feverMultiplier: 3.0, coffeeCount: 999, energyDrinkCount: 999, onClose: {}, onCoffee: {}, onEnergyDrink: {})
+    }
+    .padding(TokenSpacing.lg)
+    .background(Color.beige200)
+}

--- a/DUDesignSystem/Sources/DUDesignSystem/Components/Bars/ProgressBar.swift
+++ b/DUDesignSystem/Sources/DUDesignSystem/Components/Bars/ProgressBar.swift
@@ -1,0 +1,140 @@
+//
+//  ProgressBar.swift
+//  DUDesignSystem
+//
+//  Created by SeoJunYoung on 6/7/26.
+//
+
+import SwiftUI
+
+public struct ProgressBar: View {
+
+    public enum ProgressBarType {
+        case `default`
+        case career(
+            currentText: String,
+            currentSubText: String,
+            goalText: String,
+            goalSubText: String
+        )
+        case mission(
+            current: Int,
+            total: Int
+        )
+        case time(
+            currentStep: Int,
+            totalStep: Int,
+            timeText: String
+        )
+    }
+
+    public var progress: Double
+    public var type: ProgressBarType
+
+    public init(progress: Double, type: ProgressBarType = .default) {
+        self.progress = max(0, min(1, progress))
+        self.type = type
+    }
+
+    private var bar: some View {
+        GeometryReader { geo in
+            ZStack(alignment: .leading) {
+                RoundedRectangle(cornerRadius: TokenRadius.ss)
+                    .fill(Color.black300.opacity(0.1))
+                    .frame(height: 16)
+
+                RoundedRectangle(cornerRadius: TokenRadius.ss)
+                    .fill(Color.orange300)
+                    .frame(width: geo.size.width * progress, height: 16)
+            }
+        }
+        .frame(height: 16)
+    }
+
+    private var missionBar: some View {
+        GeometryReader { geo in
+            ZStack {
+                RoundedRectangle(cornerRadius: TokenRadius.ss)
+                    .fill(Color.black300.opacity(0.1))
+                    .frame(height: 16)
+
+                RoundedRectangle(cornerRadius: TokenRadius.ss)
+                    .fill(Color.orange300)
+                    .frame(width: geo.size.width * progress, height: 16)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                if case .mission(let current, let total) = type {
+                    Text("\(current)/\(total)")
+                        .duFont(.caption)
+                        .foregroundStyle(Color.black300)
+                }
+            }
+        }
+        .frame(height: 16)
+    }
+
+    public var body: some View {
+        switch type {
+        case .default:
+            bar
+
+        case .career(let currentText, let currentSubText, let goalText, let goalSubText):
+            VStack(spacing: TokenSpacing.xs) {
+                bar
+                VStack(spacing: 1) {
+                    HStack {
+                        ItemLabel(text: currentText, icon: .coinBag, size: .small, color: .black)
+                        Spacer()
+                        ItemLabel(text: goalText, icon: .coinBag, size: .small, color: .black)
+                    }
+                    HStack {
+                        Text(currentSubText)
+                            .duFont(.caption)
+                            .foregroundStyle(Color.black300)
+                        Spacer()
+                        Text(goalSubText)
+                            .duFont(.caption)
+                            .foregroundStyle(Color.black300)
+                    }
+                }
+            }
+
+        case .mission:
+            missionBar
+
+        case .time(let currentStep, let totalStep, let timeText):
+            VStack(spacing: TokenSpacing.xs) {
+                HStack {
+                    Text("\(currentStep) / \(totalStep)")
+                        .duFont(.caption)
+                        .foregroundStyle(Color.black300)
+                    Spacer()
+                    Text(timeText)
+                        .duFont(.caption)
+                        .foregroundStyle(Color.black300)
+                }
+                bar
+            }
+        }
+    }
+}
+
+#Preview {
+    VStack(spacing: TokenSpacing.lg) {
+        ProgressBar(progress: 0.6)
+
+        ProgressBar(progress: 0.4, type: .career(
+            currentText: "20,000",
+            currentSubText: "누적",
+            goalText: "20,000",
+            goalSubText: "개발자 지망생"
+        ))
+
+        ProgressBar(progress: 0.9, type: .mission(current: 9, total: 10))
+
+        ProgressBar(progress: 0.3, type: .time(currentStep: 1, totalStep: 3, timeText: "남은 시간 30s"))
+        ProgressBar(progress: 0, type: .time(currentStep: 1, totalStep: 3, timeText: "제한시간종료"))
+    }
+    .padding(TokenSpacing.lg)
+    .background(Color.beige200)
+}

--- a/DUDesignSystem/Sources/DUDesignSystem/Components/Bars/StatusBar.swift
+++ b/DUDesignSystem/Sources/DUDesignSystem/Components/Bars/StatusBar.swift
@@ -12,15 +12,15 @@ public struct StatusBar: View {
     public var imageName: String
     public var careerNickname: String
     public var careerProgress: Double
-    public var gold: Int
-    public var diamond: Int
+    public var gold: String
+    public var diamond: String
 
     public init(
         imageName: String,
         careerNickname: String,
         careerProgress: Double,
-        gold: Int,
-        diamond: Int
+        gold: String,
+        diamond: String
     ) {
         self.imageName = imageName
         self.careerNickname = careerNickname
@@ -57,8 +57,8 @@ public struct StatusBar: View {
             Spacer()
 
             HStack(spacing: TokenSpacing.xs) {
-                ItemLabel(text: "\(gold)", icon: .coinBag, size: .small, color: .black)
-                ItemLabel(text: "\(diamond)", icon: .diamond, size: .small, color: .black)
+                ItemLabel(text: gold, icon: .coinBag, size: .small, color: .black)
+                ItemLabel(text: diamond, icon: .diamond, size: .small, color: .black)
             }
         }
     }
@@ -83,15 +83,15 @@ public struct StatusBar: View {
             imageName: "icon_coffee",
             careerNickname: "개발자 지망생 소피아",
             careerProgress: 0.3,
-            gold: 20000,
-            diamond: 20
+            gold: "20,000",
+            diamond: "20"
         )
         StatusBar(
             imageName: "icon_coffee",
             careerNickname: "개발자 지망생 소피아",
             careerProgress: 0.7,
-            gold: 20000,
-            diamond: 20
+            gold: "20,000",
+            diamond: "20"
         )
     }
     .padding(TokenSpacing.lg)

--- a/DUDesignSystem/Sources/DUDesignSystem/Components/Bars/StatusBar.swift
+++ b/DUDesignSystem/Sources/DUDesignSystem/Components/Bars/StatusBar.swift
@@ -1,0 +1,99 @@
+//
+//  StatusBar.swift
+//  DUDesignSystem
+//
+//  Created by SeoJunYoung on 6/7/26.
+//
+
+import SwiftUI
+
+public struct StatusBar: View {
+
+    public var imageName: String
+    public var careerNickname: String
+    public var careerProgress: Double
+    public var gold: Int
+    public var diamond: Int
+
+    public init(
+        imageName: String,
+        careerNickname: String,
+        careerProgress: Double,
+        gold: Int,
+        diamond: Int
+    ) {
+        self.imageName = imageName
+        self.careerNickname = careerNickname
+        self.careerProgress = max(0, min(1, careerProgress))
+        self.gold = gold
+        self.diamond = diamond
+    }
+
+    public var body: some View {
+        HStack {
+            HStack(spacing: TokenSpacing.sm) {
+                RoundedRectangle(cornerRadius: TokenRadius.ss)
+                    .fill(Color.black300)
+                    .frame(width: 30, height: 30)
+                    .overlay(
+                        Image(imageName)
+                            .resizable()
+                            .scaledToFill()
+                            .frame(width: 30, height: 30)
+                            .clipShape(RoundedRectangle(cornerRadius: TokenRadius.ss))
+                    )
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(careerNickname)
+                        .duFont(.caption)
+                        .foregroundStyle(Color.black300)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.5)
+
+                    careerProgressBar
+                }
+            }
+
+            Spacer()
+
+            HStack(spacing: TokenSpacing.xs) {
+                ItemLabel(text: "\(gold)", icon: .coinBag, size: .small, color: .black)
+                ItemLabel(text: "\(diamond)", icon: .diamond, size: .small, color: .black)
+            }
+        }
+    }
+
+    private var careerProgressBar: some View {
+        ZStack(alignment: .leading) {
+            Capsule()
+                .fill(Color.black300PopUpDimStatusBar)
+                .frame(width: 101, height: 10)
+
+            Capsule()
+                .fill(Color.lightOrange)
+                .frame(width: 101 * careerProgress, height: 10)
+        }
+        .frame(width: 101, height: 10)
+    }
+}
+
+#Preview {
+    VStack(spacing: TokenSpacing.lg) {
+        StatusBar(
+            imageName: "icon_coffee",
+            careerNickname: "개발자 지망생 소피아",
+            careerProgress: 0.3,
+            gold: 20000,
+            diamond: 20
+        )
+        StatusBar(
+            imageName: "icon_coffee",
+            careerNickname: "개발자 지망생 소피아",
+            careerProgress: 0.7,
+            gold: 20000,
+            diamond: 20
+        )
+    }
+    .padding(TokenSpacing.lg)
+    .background(Color.beige200)
+}

--- a/DUDesignSystem/Sources/DUDesignSystem/Components/Buttons/TextButton.swift
+++ b/DUDesignSystem/Sources/DUDesignSystem/Components/Buttons/TextButton.swift
@@ -71,7 +71,7 @@ public struct TextButton: View {
     public var body: some View {
         ZStack(alignment: .topTrailing) {
             ZStack {
-                ItemLabel(text: text, icon: nil, size: .large, color: labelColor)
+                ItemLabel(text: text, icon: nil, size: size == .large ? .large : .medium, color: labelColor)
                     .opacity(state == .locked ? TokenOpacity.opacity40 : TokenOpacity.opacity100)
                 if state == .locked {
                     DUIcon(.lock, size: .size15)
@@ -80,7 +80,7 @@ public struct TextButton: View {
             .frame(maxWidth: size == .large ? .infinity : 200)
             .padding(.vertical, TokenSpacing.mm)
             .background(backgroundColor)
-            .clipShape(RoundedRectangle(cornerRadius: TokenRadius.md))
+            .clipShape(RoundedRectangle(cornerRadius: TokenRadius.sm))
             .tokenShadow(isPressed ? .none : .dim)
             .gesture(
                 isInteractive ? DragGesture(minimumDistance: 0)

--- a/DUDesignSystem/Sources/DUDesignSystem/Components/InputField.swift
+++ b/DUDesignSystem/Sources/DUDesignSystem/Components/InputField.swift
@@ -43,17 +43,17 @@ public struct InputField: View {
         VStack(alignment: .trailing, spacing: TokenSpacing.xs) {
             HStack {
                 ZStack(alignment: .leading) {
-                    if text.isEmpty && !isFocused {
-                        Text(placeholder)
-                            .duFont(.body)
-                            .foregroundStyle(Color.gray200)
-                    }
+                    Text(placeholder)
+                        .duFont(.body)
+                        .foregroundStyle(Color.gray200)
+                        .opacity(text.isEmpty && !isFocused ? 1 : 0)
                     TextField("", text: $text)
                         .duFont(.body)
                         .foregroundStyle(Color.black300)
                         .tint(Color.black300)
                         .focused($isFocused)
                 }
+                .frame(height: 24)
 
                 if case .error = state {
                     Image(systemName: "exclamationmark.circle.fill")

--- a/DUDesignSystem/Sources/DUDesignSystem/Components/InputField.swift
+++ b/DUDesignSystem/Sources/DUDesignSystem/Components/InputField.swift
@@ -1,0 +1,94 @@
+//
+//  InputField.swift
+//  DUDesignSystem
+//
+//  Created by SeoJunYoung on 6/7/26.
+//
+
+import SwiftUI
+
+public struct InputField: View {
+
+    public enum InputFieldState {
+        case `default`
+        case error(message: String)
+        case success
+    }
+
+    @Binding public var text: String
+    public var placeholder: String
+    public var state: InputFieldState
+
+    @FocusState private var isFocused: Bool
+
+    public init(
+        text: Binding<String>,
+        placeholder: String,
+        state: InputFieldState = .default
+    ) {
+        self._text = text
+        self.placeholder = placeholder
+        self.state = state
+    }
+
+    private var borderColor: Color {
+        switch state {
+        case .default: return Color.black300GrayBar
+        case .error:   return Color.accentRed
+        case .success: return Color.black300
+        }
+    }
+
+    public var body: some View {
+        VStack(alignment: .trailing, spacing: TokenSpacing.xs) {
+            HStack {
+                ZStack(alignment: .leading) {
+                    if text.isEmpty && !isFocused {
+                        Text(placeholder)
+                            .duFont(.body)
+                            .foregroundStyle(Color.gray200)
+                    }
+                    TextField("", text: $text)
+                        .duFont(.body)
+                        .foregroundStyle(Color.black300)
+                        .tint(Color.black300)
+                        .focused($isFocused)
+                }
+
+                if case .error = state {
+                    Image(systemName: "exclamationmark.circle.fill")
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: 16, height: 16)
+                        .foregroundStyle(Color.accentRed)
+                }
+            }
+            .padding(.vertical, TokenSpacing.mm)
+            .padding(.horizontal, TokenSpacing.md)
+            .background(Color.white300StatusBar)
+            .clipShape(RoundedRectangle(cornerRadius: TokenRadius.sm))
+            .overlay(
+                RoundedRectangle(cornerRadius: TokenRadius.sm)
+                    .stroke(borderColor, lineWidth: 1)
+            )
+
+            if case .error(let message) = state {
+                Text(message)
+                    .duFont(.label)
+                    .foregroundStyle(Color.accentRed)
+                    .padding(.trailing, TokenSpacing.xs)
+            }
+        }
+    }
+}
+
+#Preview {
+    VStack(spacing: TokenSpacing.md) {
+        InputField(text: .constant(""), placeholder: "닉네임을 입력해주세요", state: .default)
+        InputField(text: .constant("소"), placeholder: "닉네임을 입력해주세요", state: .error(message: "닉네임은 1자 이상 입력해주세요."))
+        InputField(text: .constant("소피아소피아소피아"), placeholder: "닉네임을 입력해주세요", state: .error(message: "닉네임은 최대 8자까지 입력할 수 있어요."))
+        InputField(text: .constant("소피아"), placeholder: "닉네임을 입력해주세요", state: .success)
+    }
+    .padding(TokenSpacing.md)
+    .background(Color.beige200)
+}

--- a/DUDesignSystem/Sources/DUDesignSystem/Components/Popup.swift
+++ b/DUDesignSystem/Sources/DUDesignSystem/Components/Popup.swift
@@ -1,0 +1,149 @@
+//
+//  Popup.swift
+//  DUDesignSystem
+//
+//  Created by SeoJunYoung on 6/7/26.
+//
+
+import SwiftUI
+
+public struct Popup: View {
+
+    public enum PopupType {
+        case notice(
+            title: String,
+            body: String,
+            buttonText: String,
+            action: () -> Void
+        )
+        case confirm(
+            title: String,
+            body: String,
+            cancelText: String,
+            confirmText: String,
+            cancelAction: () -> Void,
+            confirmAction: () -> Void
+        )
+        case reward(
+            title: String,
+            body: String,
+            rewardLeadingText: String,
+            rewardIcon: DUIconName,
+            rewardTrailingText: String,
+            buttonText: String,
+            action: () -> Void
+        )
+    }
+
+    public var type: PopupType
+
+    public init(type: PopupType) {
+        self.type = type
+    }
+
+    private var titleText: String {
+        switch type {
+        case .notice(let t, _, _, _):       return t
+        case .confirm(let t, _, _, _, _, _): return t
+        case .reward(let t, _, _, _, _, _, _): return t
+        }
+    }
+
+    private var bodyText: String {
+        switch type {
+        case .notice(_, let b, _, _):       return b
+        case .confirm(_, let b, _, _, _, _): return b
+        case .reward(_, let b, _, _, _, _, _): return b
+        }
+    }
+
+    @ViewBuilder
+    private var buttonSection: some View {
+        switch type {
+        case .notice(_, _, let text, let action):
+            TextButton(text: text, type: .primary, size: .medium, action: action)
+
+        case .confirm(_, _, let cancelText, let confirmText, let cancelAction, let confirmAction):
+            HStack(spacing: TokenSpacing.sm) {
+                TextButton(text: cancelText, type: .secondary, size: .medium, action: cancelAction)
+                TextButton(text: confirmText, type: .primary, size: .medium, action: confirmAction)
+            }
+
+        case .reward(_, _, _, _, _, let text, let action):
+            TextButton(text: text, type: .primary, size: .medium, action: action)
+        }
+    }
+
+    private var isBodyLeadingAligned: Bool {
+        if case .confirm = type { return false }
+        return true
+    }
+
+    public var body: some View {
+        VStack(spacing: TokenSpacing.lg) {
+            Text(titleText)
+                .duFont(.title2)
+                .foregroundStyle(Color.black300)
+                .multilineTextAlignment(.center)
+
+            Text(bodyText)
+                .duFont(.body)
+                .foregroundStyle(Color.black300)
+                .multilineTextAlignment(isBodyLeadingAligned ? .leading : .center)
+                .frame(maxWidth: .infinity, alignment: isBodyLeadingAligned ? .leading : .center)
+
+            if case .reward(_, _, let leading, let icon, let trailing, _, _) = type {
+                HStack(spacing: TokenSpacing.xs) {
+                    Text(leading)
+                        .duFont(.body)
+                        .foregroundStyle(Color.black300)
+                    DUIcon(icon, size: .size18)
+                    Text(trailing)
+                        .duFont(.body)
+                        .foregroundStyle(Color.black300)
+                }
+            }
+
+            buttonSection
+        }
+        .frame(maxWidth: .infinity)
+        .padding(TokenSpacing.lg)
+        .background(Color.white300)
+        .clipShape(RoundedRectangle(cornerRadius: TokenRadius.lg))
+        .overlay(
+            RoundedRectangle(cornerRadius: TokenRadius.lg)
+                .stroke(Color.gray700, lineWidth: 2)
+        )
+        .padding(.horizontal, TokenSpacing.lg)
+    }
+}
+
+#Preview {
+    VStack(spacing: TokenSpacing.lg) {
+        Popup(type: .notice(
+            title: "팝업 타이틀",
+            body: "팝업 내용 내용 내용 내용 내용 내용 내용 내용\n내용 내용",
+            buttonText: "닫기",
+            action: {}
+        ))
+        Popup(type: .confirm(
+            title: "팝업 타이틀",
+            body: "팝업 내용 내용 내용 내용 내용 내용 내용 내용\n내용 내용",
+            cancelText: "취소",
+            confirmText: "구매",
+            cancelAction: {},
+            confirmAction: {}
+        ))
+        Popup(type: .reward(
+            title: "팝업 타이틀",
+            body: "팝업 내용 내용 내용 내용 내용 내용 내용 내용\n내용 내용",
+            rewardLeadingText: "직득한 다이아 : ",
+            rewardIcon: .diamond,
+            rewardTrailingText: "20",
+            buttonText: "닫기",
+            action: {}
+        ))
+    }
+    .padding(.vertical, TokenSpacing.lg)
+    .background(Color.beige200)
+}

--- a/DUDesignSystem/Sources/DUDesignSystem/Components/Toast.swift
+++ b/DUDesignSystem/Sources/DUDesignSystem/Components/Toast.swift
@@ -1,0 +1,37 @@
+//
+//  Toast.swift
+//  DUDesignSystem
+//
+//  Created by SeoJunYoung on 6/7/26.
+//
+
+import SwiftUI
+
+public struct Toast: View {
+
+    public var message: String
+
+    public init(message: String) {
+        self.message = message
+    }
+
+    public var body: some View {
+        Text(message)
+            .duFont(.body)
+            .foregroundStyle(Color.white300)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, TokenSpacing.mm)
+            .background(Color.black300.opacity(0.8))
+            .clipShape(RoundedRectangle(cornerRadius: TokenRadius.sm))
+            .tokenShadow(.dim)
+            .padding(.horizontal, TokenSpacing.lg)
+    }
+}
+
+#Preview {
+    VStack(spacing: TokenSpacing.md) {
+        Toast(message: "토스트 안내 메시지입니다.")
+        Toast(message: "저장되었습니다.")
+    }
+    .background(Color.beige200)
+}

--- a/SoloDeveloperTraining/DUDesignSystemExample/Component/ComponentDefaultLabelView.swift
+++ b/SoloDeveloperTraining/DUDesignSystemExample/Component/ComponentDefaultLabelView.swift
@@ -14,71 +14,60 @@ struct ComponentDefaultLabelView: View {
     @State private var selectedIcon: DUIconName? = .ad
 
     var body: some View {
-        List {
-            // MARK: - Preview
-            Section {
+        VStack(spacing: 0) {
+            // MARK: - Preview Area
+            PreviewArea {
                 ItemLabel(text: text, icon: selectedIcon, size: selectedSize, color: selectedColor)
                     .frame(maxWidth: .infinity, alignment: .center)
-                    .padding(.vertical, TokenSpacing.lg)
-                    .background(
-                        LinearGradient(
-                            colors: [Color.gray700, Color.beige50],
-                            startPoint: .leading,
-                            endPoint: .trailing
-                        )
-                        .clipShape(RoundedRectangle(cornerRadius: TokenRadius.md))
-                    )
             }
-            .listRowBackground(Color.clear)
 
-            // MARK: - 텍스트
-            Section("텍스트") {
-                HStack {
-                    TextField("텍스트 입력", text: $text)
-                    if !text.isEmpty {
-                        Button { text = "" } label: {
-                            Image(systemName: "xmark.circle.fill")
-                                .foregroundStyle(Color.gray400)
+            // MARK: - Controls
+            List {
+                Section("텍스트") {
+                    HStack {
+                        TextField("텍스트 입력", text: $text)
+                        if !text.isEmpty {
+                            Button { text = "" } label: {
+                                Image(systemName: "xmark.circle.fill")
+                                    .foregroundStyle(Color.gray400)
+                            }
+                            .buttonStyle(.plain)
                         }
-                        .buttonStyle(.plain)
+                    }
+                }
+
+                Section("크기") {
+                    Picker("크기", selection: $selectedSize) {
+                        Text("Small").tag(ItemLabel.LabelSize.small)
+                        Text("Medium").tag(ItemLabel.LabelSize.medium)
+                        Text("Large").tag(ItemLabel.LabelSize.large)
+                    }
+                    .pickerStyle(.segmented)
+                }
+                .listRowBackground(Color.clear)
+                .listRowInsets(.init(top: 0, leading: 0, bottom: 0, trailing: 0))
+
+                Section("색상") {
+                    Picker("색상", selection: $selectedColor) {
+                        Text("White").tag(ItemLabel.LabelColor.white)
+                        Text("Black").tag(ItemLabel.LabelColor.black)
+                    }
+                    .pickerStyle(.segmented)
+                }
+                .listRowBackground(Color.clear)
+                .listRowInsets(.init(top: 0, leading: 0, bottom: 0, trailing: 0))
+
+                Section("아이콘") {
+                    Picker("아이콘", selection: $selectedIcon) {
+                        Text("없음").tag(Optional<DUIconName>.none)
+                        ForEach(DUIconName.allCases, id: \.self) { icon in
+                            Text(".\(icon)").tag(Optional(icon))
+                        }
                     }
                 }
             }
-
-            // MARK: - 크기
-            Section("크기") {
-                Picker("크기", selection: $selectedSize) {
-                    Text("Small").tag(ItemLabel.LabelSize.small)
-                    Text("Medium").tag(ItemLabel.LabelSize.medium)
-                    Text("Large").tag(ItemLabel.LabelSize.large)
-                }
-                .pickerStyle(.segmented)
-            }
-            .listRowBackground(Color.clear)
-            .listRowInsets(.init(top: 0, leading: 0, bottom: 0, trailing: 0))
-
-            // MARK: - 색상
-            Section("색상") {
-                Picker("색상", selection: $selectedColor) {
-                    Text("White").tag(ItemLabel.LabelColor.white)
-                    Text("Black").tag(ItemLabel.LabelColor.black)
-                }
-                .pickerStyle(.segmented)
-            }
-            .listRowBackground(Color.clear)
-            .listRowInsets(.init(top: 0, leading: 0, bottom: 0, trailing: 0))
-
-            // MARK: - 아이콘
-            Section("아이콘") {
-                Picker("아이콘", selection: $selectedIcon) {
-                    Text("없음").tag(Optional<DUIconName>.none)
-                    ForEach(DUIconName.allCases, id: \.self) { icon in
-                        Text(".\(icon)").tag(Optional(icon))
-                    }
-                }
-            }
+            .scrollContentBackground(.hidden)
         }
-        .scrollContentBackground(.hidden)
         .background(Color.beige200)
         .navigationTitle("DefaultLabel")
         .navigationSubtitle("조합을 선택해 컴포넌트를 확인해보세요")

--- a/SoloDeveloperTraining/DUDesignSystemExample/Component/ComponentEffectLabelView.swift
+++ b/SoloDeveloperTraining/DUDesignSystemExample/Component/ComponentEffectLabelView.swift
@@ -13,48 +13,46 @@ struct ComponentEffectLabelView: View {
     @State private var opacity: Double = 1.0
 
     var body: some View {
-        List {
-            // MARK: - Preview
-            Section {
+        VStack(spacing: 0) {
+            // MARK: - Preview Area
+            PreviewArea {
                 EffectLabel(type: selectedType, text: text)
                     .frame(maxWidth: .infinity, alignment: .center)
-                    .padding(.vertical, TokenSpacing.lg)
                     .opacity(opacity)
             }
-            .listRowBackground(Color.clear)
 
-            // MARK: - 텍스트
-            Section("텍스트") {
-                HStack {
-                    TextField("텍스트 입력", text: $text)
-                    if !text.isEmpty {
-                        Button { text = "" } label: {
-                            Image(systemName: "xmark.circle.fill")
-                                .foregroundStyle(Color.gray400)
+            // MARK: - Controls
+            List {
+                Section("텍스트") {
+                    HStack {
+                        TextField("텍스트 입력", text: $text)
+                        if !text.isEmpty {
+                            Button { text = "" } label: {
+                                Image(systemName: "xmark.circle.fill")
+                                    .foregroundStyle(Color.gray400)
+                            }
+                            .buttonStyle(.plain)
                         }
-                        .buttonStyle(.plain)
                     }
                 }
-            }
 
-            // MARK: - 타입
-            Section("타입") {
-                Picker("타입", selection: $selectedType) {
-                    Text("Plus").tag(EffectLabel.EffectLabelType.plus)
-                    Text("Minus").tag(EffectLabel.EffectLabelType.minus)
+                Section("타입") {
+                    Picker("타입", selection: $selectedType) {
+                        Text("Plus").tag(EffectLabel.EffectLabelType.plus)
+                        Text("Minus").tag(EffectLabel.EffectLabelType.minus)
+                    }
+                    .pickerStyle(.segmented)
                 }
-                .pickerStyle(.segmented)
-            }
-            .listRowBackground(Color.clear)
-            .listRowInsets(.init(top: 0, leading: 0, bottom: 0, trailing: 0))
+                .listRowBackground(Color.clear)
+                .listRowInsets(.init(top: 0, leading: 0, bottom: 0, trailing: 0))
 
-            // MARK: - Opacity
-            Section("Opacity  \(String(format: "%.2f", opacity))") {
-                Slider(value: $opacity, in: 0...1)
-                    .tint(Color.orange300)
+                Section("Opacity  \(String(format: "%.2f", opacity))") {
+                    Slider(value: $opacity, in: 0...1)
+                        .tint(Color.orange300)
+                }
             }
+            .scrollContentBackground(.hidden)
         }
-        .scrollContentBackground(.hidden)
         .background(Color.beige200)
         .navigationTitle("EffectLabel")
         .navigationSubtitle("코인 획득/차감 효과 레이블")

--- a/SoloDeveloperTraining/DUDesignSystemExample/Component/ComponentGameToolBarView.swift
+++ b/SoloDeveloperTraining/DUDesignSystemExample/Component/ComponentGameToolBarView.swift
@@ -1,0 +1,78 @@
+//
+//  ComponentGameToolBarView.swift
+//  DUDesignSystemExample
+//
+
+import SwiftUI
+import DUDesignSystem
+
+struct ComponentGameToolBarView: View {
+
+    @State private var feverStage: Int = 0
+    @State private var feverProgress: Double = 0.0
+    @State private var coffeeCount: Int = 5
+    @State private var energyDrinkCount: Int = 3
+
+    private var feverMultiplier: Double {
+        feverStage == 0 ? 0 : Double(feverStage) * 1.0
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // MARK: - Preview Area
+            PreviewArea {
+                GameToolBar(
+                    feverStage: feverStage,
+                    feverProgress: feverProgress,
+                    feverMultiplier: feverMultiplier,
+                    coffeeCount: coffeeCount,
+                    energyDrinkCount: energyDrinkCount,
+                    onClose: {},
+                    onCoffee: {},
+                    onEnergyDrink: {}
+                )
+            }
+
+            // MARK: - Controls
+            List {
+                Section("피버 단계") {
+                    Picker("단계", selection: $feverStage) {
+                        Text("0").tag(0)
+                        Text("1").tag(1)
+                        Text("2").tag(2)
+                        Text("3").tag(3)
+                    }
+                    .pickerStyle(.segmented)
+                }
+                .listRowBackground(Color.clear)
+                .listRowInsets(.init(top: 0, leading: 0, bottom: 0, trailing: 0))
+
+                Section("피버 진행도") {
+                    Slider(value: $feverProgress, in: 0...1)
+                    Text("\(Int(feverProgress * 100))%")
+                        .foregroundStyle(Color.gray400)
+                }
+
+                Section("아이템 개수") {
+                    Stepper("커피: \(coffeeCount)", value: $coffeeCount, in: 0...999)
+                    Stepper("에너지드링크: \(energyDrinkCount)", value: $energyDrinkCount, in: 0...999)
+                }
+
+                Section {
+                    Text("상태 변경이나 유효성 검사는 비즈니스 로직이므로 예시 앱에는 반영되지 않아요.")
+                        .font(.caption)
+                        .foregroundStyle(Color.gray400)
+                }
+            }
+            .scrollContentBackground(.hidden)
+        }
+        .background(Color.beige200)
+        .navigationTitle("GameToolBar")
+    }
+}
+
+#Preview {
+    NavigationStack {
+        ComponentGameToolBarView()
+    }
+}

--- a/SoloDeveloperTraining/DUDesignSystemExample/Component/ComponentInputFieldView.swift
+++ b/SoloDeveloperTraining/DUDesignSystemExample/Component/ComponentInputFieldView.swift
@@ -1,0 +1,70 @@
+//
+//  ComponentInputFieldView.swift
+//  DUDesignSystemExample
+//
+
+import SwiftUI
+import DUDesignSystem
+
+struct ComponentInputFieldView: View {
+
+    enum StateOption: String, CaseIterable {
+        case `default` = "Default"
+        case error     = "Error"
+        case success   = "Success"
+    }
+
+    @State private var text: String = ""
+    @State private var placeholder: String = "닉네임을 입력해주세요"
+    @State private var selectedState: StateOption = .default
+    @State private var errorMessage: String = "닉네임은 1자 이상 입력해주세요."
+
+    private var inputFieldState: InputField.InputFieldState {
+        switch selectedState {
+        case .default: return .default
+        case .error:   return .error(message: errorMessage)
+        case .success: return .success
+        }
+    }
+
+    var body: some View {
+        List {
+            // MARK: - Preview
+            Section {
+                InputField(text: $text, placeholder: placeholder, state: inputFieldState)
+                    .padding(.vertical, TokenSpacing.lg)
+            }
+            .listRowBackground(Color.clear)
+            .listRowInsets(.init(top: 0, leading: TokenSpacing.md, bottom: 0, trailing: TokenSpacing.md))
+
+            // MARK: - 상태
+            Section("상태") {
+                Picker("상태", selection: $selectedState) {
+                    ForEach(StateOption.allCases, id: \.self) { option in
+                        Text(option.rawValue).tag(option)
+                    }
+                }
+                .pickerStyle(.segmented)
+            }
+            .listRowBackground(Color.clear)
+            .listRowInsets(.init(top: 0, leading: 0, bottom: 0, trailing: 0))
+
+            // MARK: - 에러 메시지
+            if selectedState == .error {
+                Section("에러 메시지") {
+                    TextField("에러 메시지 입력", text: $errorMessage)
+                }
+            }
+        }
+        .scrollContentBackground(.hidden)
+        .background(Color.beige200)
+        .navigationTitle("InputField")
+        .navigationSubtitle("상태 변경 및 유효성 검사는 비즈니스 로직으로, 예시 앱에서는 반영되지 않아요")
+    }
+}
+
+#Preview {
+    NavigationStack {
+        ComponentInputFieldView()
+    }
+}

--- a/SoloDeveloperTraining/DUDesignSystemExample/Component/ComponentInputFieldView.swift
+++ b/SoloDeveloperTraining/DUDesignSystemExample/Component/ComponentInputFieldView.swift
@@ -28,35 +28,34 @@ struct ComponentInputFieldView: View {
     }
 
     var body: some View {
-        List {
-            // MARK: - Preview
-            Section {
+        VStack(spacing: 0) {
+            // MARK: - Preview Area
+            PreviewArea {
                 InputField(text: $text, placeholder: placeholder, state: inputFieldState)
-                    .padding(.vertical, TokenSpacing.lg)
+                    .frame(maxWidth: .infinity)
             }
-            .listRowBackground(Color.clear)
-            .listRowInsets(.init(top: 0, leading: TokenSpacing.md, bottom: 0, trailing: TokenSpacing.md))
 
-            // MARK: - 상태
-            Section("상태") {
-                Picker("상태", selection: $selectedState) {
-                    ForEach(StateOption.allCases, id: \.self) { option in
-                        Text(option.rawValue).tag(option)
+            // MARK: - Controls
+            List {
+                Section("상태") {
+                    Picker("상태", selection: $selectedState) {
+                        ForEach(StateOption.allCases, id: \.self) { option in
+                            Text(option.rawValue).tag(option)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                }
+                .listRowBackground(Color.clear)
+                .listRowInsets(.init(top: 0, leading: 0, bottom: 0, trailing: 0))
+
+                if selectedState == .error {
+                    Section("에러 메시지") {
+                        TextField("에러 메시지 입력", text: $errorMessage)
                     }
                 }
-                .pickerStyle(.segmented)
             }
-            .listRowBackground(Color.clear)
-            .listRowInsets(.init(top: 0, leading: 0, bottom: 0, trailing: 0))
-
-            // MARK: - 에러 메시지
-            if selectedState == .error {
-                Section("에러 메시지") {
-                    TextField("에러 메시지 입력", text: $errorMessage)
-                }
-            }
+            .scrollContentBackground(.hidden)
         }
-        .scrollContentBackground(.hidden)
         .background(Color.beige200)
         .navigationTitle("InputField")
         .navigationSubtitle("상태 변경 및 유효성 검사는 비즈니스 로직으로, 예시 앱에서는 반영되지 않아요")

--- a/SoloDeveloperTraining/DUDesignSystemExample/Component/ComponentItemButtonView.swift
+++ b/SoloDeveloperTraining/DUDesignSystemExample/Component/ComponentItemButtonView.swift
@@ -26,9 +26,9 @@ struct ComponentItemButtonView: View {
     }
 
     var body: some View {
-        List {
-            // MARK: - Preview
-            Section {
+        VStack(spacing: 0) {
+            // MARK: - Preview Area
+            PreviewArea {
                 VStack(spacing: TokenSpacing.sm) {
                     Text(stateLabel)
                         .duFont(.caption)
@@ -43,37 +43,36 @@ struct ComponentItemButtonView: View {
                         )
                 }
                 .frame(maxWidth: .infinity, alignment: .center)
-                .padding(.vertical, TokenSpacing.lg)
             }
-            .listRowBackground(Color.clear)
 
-            // MARK: - 텍스트
-            Section("텍스트") {
-                HStack {
-                    TextField("텍스트 입력", text: $text)
-                    if !text.isEmpty {
-                        Button { text = "" } label: {
-                            Image(systemName: "xmark.circle.fill")
-                                .foregroundStyle(Color.gray400)
+            // MARK: - Controls
+            List {
+                Section("텍스트") {
+                    HStack {
+                        TextField("텍스트 입력", text: $text)
+                        if !text.isEmpty {
+                            Button { text = "" } label: {
+                                Image(systemName: "xmark.circle.fill")
+                                    .foregroundStyle(Color.gray400)
+                            }
+                            .buttonStyle(.plain)
                         }
-                        .buttonStyle(.plain)
                     }
                 }
-            }
 
-            // MARK: - 상태
-            Section("상태") {
-                Picker("상태", selection: $selectedState) {
-                    Text("Default").tag(ItemButton.ItemButtonState.default)
-                    Text("Locked").tag(ItemButton.ItemButtonState.locked)
-                    Text("Disabled").tag(ItemButton.ItemButtonState.disabled)
+                Section("상태") {
+                    Picker("상태", selection: $selectedState) {
+                        Text("Default").tag(ItemButton.ItemButtonState.default)
+                        Text("Locked").tag(ItemButton.ItemButtonState.locked)
+                        Text("Disabled").tag(ItemButton.ItemButtonState.disabled)
+                    }
+                    .pickerStyle(.segmented)
                 }
-                .pickerStyle(.segmented)
+                .listRowBackground(Color.clear)
+                .listRowInsets(.init(top: 0, leading: 0, bottom: 0, trailing: 0))
             }
-            .listRowBackground(Color.clear)
-            .listRowInsets(.init(top: 0, leading: 0, bottom: 0, trailing: 0))
+            .scrollContentBackground(.hidden)
         }
-        .scrollContentBackground(.hidden)
         .background(Color.beige200)
         .navigationTitle("ItemButton")
         .navigationSubtitle("누르고 있으면 pressed 상태를 확인할 수 있어요")

--- a/SoloDeveloperTraining/DUDesignSystemExample/Component/ComponentListView.swift
+++ b/SoloDeveloperTraining/DUDesignSystemExample/Component/ComponentListView.swift
@@ -22,6 +22,7 @@ struct ComponentListView: View {
         ("InputField", "text.cursor", AnyView(ComponentInputFieldView())),
         ("Toast", "text.bubble", AnyView(ComponentToastView())),
         ("Popup", "rectangle.on.rectangle", AnyView(ComponentPopupView())),
+        ("ProgressBar", "chart.bar", AnyView(ComponentProgressBarView())),
     ]
 
     private let columns = [GridItem(.flexible()), GridItem(.flexible())]

--- a/SoloDeveloperTraining/DUDesignSystemExample/Component/ComponentListView.swift
+++ b/SoloDeveloperTraining/DUDesignSystemExample/Component/ComponentListView.swift
@@ -24,6 +24,7 @@ struct ComponentListView: View {
         ("Popup", "rectangle.on.rectangle", AnyView(ComponentPopupView())),
         ("ProgressBar", "chart.bar", AnyView(ComponentProgressBarView())),
         ("GameToolBar", "gamecontroller", AnyView(ComponentGameToolBarView())),
+        ("StatusBar", "person.crop.rectangle", AnyView(ComponentStatusBarView())),
     ]
 
     private let columns = [GridItem(.flexible()), GridItem(.flexible())]

--- a/SoloDeveloperTraining/DUDesignSystemExample/Component/ComponentListView.swift
+++ b/SoloDeveloperTraining/DUDesignSystemExample/Component/ComponentListView.swift
@@ -20,6 +20,7 @@ struct ComponentListView: View {
         ("SmallButton", "smallcircle.filled.circle", AnyView(ComponentSmallButtonView())),
         ("QuizButton", "questionmark.circle", AnyView(ComponentQuizButtonView())),
         ("InputField", "text.cursor", AnyView(ComponentInputFieldView())),
+        ("Toast", "text.bubble", AnyView(ComponentToastView())),
     ]
 
     private let columns = [GridItem(.flexible()), GridItem(.flexible())]

--- a/SoloDeveloperTraining/DUDesignSystemExample/Component/ComponentListView.swift
+++ b/SoloDeveloperTraining/DUDesignSystemExample/Component/ComponentListView.swift
@@ -19,6 +19,7 @@ struct ComponentListView: View {
         ("SegmentControl", "rectangle.split.2x1", AnyView(ComponentSegmentControlView())),
         ("SmallButton", "smallcircle.filled.circle", AnyView(ComponentSmallButtonView())),
         ("QuizButton", "questionmark.circle", AnyView(ComponentQuizButtonView())),
+        ("InputField", "text.cursor", AnyView(ComponentInputFieldView())),
     ]
 
     private let columns = [GridItem(.flexible()), GridItem(.flexible())]

--- a/SoloDeveloperTraining/DUDesignSystemExample/Component/ComponentListView.swift
+++ b/SoloDeveloperTraining/DUDesignSystemExample/Component/ComponentListView.swift
@@ -23,6 +23,7 @@ struct ComponentListView: View {
         ("Toast", "text.bubble", AnyView(ComponentToastView())),
         ("Popup", "rectangle.on.rectangle", AnyView(ComponentPopupView())),
         ("ProgressBar", "chart.bar", AnyView(ComponentProgressBarView())),
+        ("GameToolBar", "gamecontroller", AnyView(ComponentGameToolBarView())),
     ]
 
     private let columns = [GridItem(.flexible()), GridItem(.flexible())]

--- a/SoloDeveloperTraining/DUDesignSystemExample/Component/ComponentListView.swift
+++ b/SoloDeveloperTraining/DUDesignSystemExample/Component/ComponentListView.swift
@@ -21,6 +21,7 @@ struct ComponentListView: View {
         ("QuizButton", "questionmark.circle", AnyView(ComponentQuizButtonView())),
         ("InputField", "text.cursor", AnyView(ComponentInputFieldView())),
         ("Toast", "text.bubble", AnyView(ComponentToastView())),
+        ("Popup", "rectangle.on.rectangle", AnyView(ComponentPopupView())),
     ]
 
     private let columns = [GridItem(.flexible()), GridItem(.flexible())]

--- a/SoloDeveloperTraining/DUDesignSystemExample/Component/ComponentPopupView.swift
+++ b/SoloDeveloperTraining/DUDesignSystemExample/Component/ComponentPopupView.swift
@@ -1,0 +1,82 @@
+//
+//  ComponentPopupView.swift
+//  DUDesignSystemExample
+//
+
+import SwiftUI
+import DUDesignSystem
+
+struct ComponentPopupView: View {
+
+    @State private var selectedType: Int = 0
+
+    private let typeLabels = ["Notice", "Confirm", "Reward"]
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // MARK: - Preview Area
+            PreviewArea {
+                Group {
+                    switch selectedType {
+                    case 0:
+                        Popup(type: .notice(
+                            title: "팝업 타이틀",
+                            body: "팝업 내용 내용 \n내용 내용",
+                            buttonText: "닫기",
+                            action: {}
+                        ))
+                    case 1:
+                        Popup(type: .confirm(
+                            title: "팝업 타이틀",
+                            body: "팝업 내용 내용 내용 내용 내용 내용 내용 내용 내용 내용\n내용 내용",
+                            cancelText: "취소",
+                            confirmText: "구매",
+                            cancelAction: {},
+                            confirmAction: {}
+                        ))
+                    default:
+                        Popup(type: .reward(
+                            title: "팝업 타이틀",
+                            body: "팝업 내용 내용 내용 내용 내용 내용 내용 내용 내용 내용\n내용 내용",
+                            rewardLeadingText: "직득한 다이아 : ",
+                            rewardIcon: .diamond,
+                            rewardTrailingText: "20",
+                            buttonText: "닫기",
+                            action: {}
+                        ))
+                    }
+                }
+                .frame(maxWidth: .infinity)
+            }
+
+            // MARK: - Controls
+            List {
+                Section("타입") {
+                    Picker("타입", selection: $selectedType) {
+                        ForEach(0..<typeLabels.count, id: \.self) { index in
+                            Text(typeLabels[index]).tag(index)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                }
+                .listRowBackground(Color.clear)
+                .listRowInsets(.init(top: 0, leading: 0, bottom: 0, trailing: 0))
+
+                Section {
+                    Text("상태 변경이나 유효성 검사는 비즈니스 로직이므로 예시 앱에는 반영되지 않아요.")
+                        .font(.caption)
+                        .foregroundStyle(Color.gray400)
+                }
+            }
+            .scrollContentBackground(.hidden)
+        }
+        .background(Color.beige200)
+        .navigationTitle("Popup")
+    }
+}
+
+#Preview {
+    NavigationStack {
+        ComponentPopupView()
+    }
+}

--- a/SoloDeveloperTraining/DUDesignSystemExample/Component/ComponentProgressBarView.swift
+++ b/SoloDeveloperTraining/DUDesignSystemExample/Component/ComponentProgressBarView.swift
@@ -1,0 +1,83 @@
+//
+//  ComponentProgressBarView.swift
+//  DUDesignSystemExample
+//
+
+import SwiftUI
+import DUDesignSystem
+
+struct ComponentProgressBarView: View {
+
+    @State private var selectedType: Int = 0
+    @State private var progress: Double = 0.6
+
+    private let typeLabels = ["Default", "Career", "Mission", "Time"]
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // MARK: - Preview Area
+            PreviewArea {
+                Group {
+                    switch selectedType {
+                    case 0:
+                        ProgressBar(progress: progress)
+
+                    case 1:
+                        ProgressBar(progress: progress, type: .career(
+                            currentText: "20,000",
+                            currentSubText: "누적",
+                            goalText: "20,000",
+                            goalSubText: "개발자 지망생"
+                        ))
+
+                    case 2:
+                        ProgressBar(progress: progress, type: .mission(current: Int(progress * 10), total: 10))
+
+                    default:
+                        ProgressBar(progress: progress, type: .time(
+                            currentStep: 1,
+                            totalStep: 3,
+                            timeText: progress > 0 ? "남은 시간 \(Int(progress * 60))s" : "제한 시간 종료"
+                        ))
+                    }
+                }
+                .padding(.horizontal, TokenSpacing.lg)
+            }
+
+            // MARK: - Controls
+            List {
+                Section("타입") {
+                    Picker("타입", selection: $selectedType) {
+                        ForEach(0..<typeLabels.count, id: \.self) { index in
+                            Text(typeLabels[index]).tag(index)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                }
+                .listRowBackground(Color.clear)
+                .listRowInsets(.init(top: 0, leading: 0, bottom: 0, trailing: 0))
+
+                Section("진행도") {
+                    Slider(value: $progress, in: 0...1)
+                    Text("\(Int(progress * 100))%")
+                        .foregroundStyle(Color.gray400)
+                }
+
+                Section {
+                    Text("상태 변경이나 유효성 검사는 비즈니스 로직이므로 예시 앱에는 반영되지 않아요.")
+                        .font(.caption)
+                        .foregroundStyle(Color.gray400)
+                }
+            }
+            .scrollContentBackground(.hidden)
+        }
+        .background(Color.beige200)
+        .navigationTitle("ProgressBar")
+    }
+}
+
+#Preview {
+    NavigationStack {
+        ComponentProgressBarView()
+    }
+}

--- a/SoloDeveloperTraining/DUDesignSystemExample/Component/ComponentQuizButtonView.swift
+++ b/SoloDeveloperTraining/DUDesignSystemExample/Component/ComponentQuizButtonView.swift
@@ -12,37 +12,44 @@ struct ComponentQuizButtonView: View {
     @State private var selectedState: QuizButton.QuizButtonState = .default
 
     var body: some View {
-        VStack(spacing: TokenSpacing.lg) {
-            QuizButton(text: text, state: selectedState) {
-                selectedState = selectedState == .selected ? .default : .selected
+        VStack(spacing: 0) {
+            // MARK: - Preview Area
+            PreviewArea {
+                QuizButton(text: text, state: selectedState) {
+                    selectedState = selectedState == .selected ? .default : .selected
+                }
+                .frame(maxWidth: .infinity)
             }
-            .padding(.horizontal, TokenGrid.paddingSide)
 
-            Picker("상태", selection: $selectedState) {
-                Text("Default").tag(QuizButton.QuizButtonState.default)
-                Text("Selected").tag(QuizButton.QuizButtonState.selected)
-            }
-            .pickerStyle(.segmented)
-            .padding(.horizontal, TokenGrid.paddingSide)
-
-            HStack {
-                TextField("텍스트 입력", text: $text)
-                    .textFieldStyle(.roundedBorder)
-                if !text.isEmpty {
-                    Button { text = "" } label: {
-                        Image(systemName: "xmark.circle.fill")
-                            .foregroundStyle(Color.gray400)
+            // MARK: - Controls
+            List {
+                Section("텍스트") {
+                    HStack {
+                        TextField("텍스트 입력", text: $text)
+                        if !text.isEmpty {
+                            Button { text = "" } label: {
+                                Image(systemName: "xmark.circle.fill")
+                                    .foregroundStyle(Color.gray400)
+                            }
+                            .buttonStyle(.plain)
+                        }
                     }
                 }
-            }
-            .padding(.horizontal, TokenGrid.paddingSide)
 
-            Spacer()
+                Section("상태") {
+                    Picker("상태", selection: $selectedState) {
+                        Text("Default").tag(QuizButton.QuizButtonState.default)
+                        Text("Selected").tag(QuizButton.QuizButtonState.selected)
+                    }
+                    .pickerStyle(.segmented)
+                }
+                .listRowBackground(Color.clear)
+                .listRowInsets(.init(top: 0, leading: 0, bottom: 0, trailing: 0))
+            }
+            .scrollContentBackground(.hidden)
         }
-        .padding(.top, TokenSpacing.lg)
         .background(Color.beige200)
         .navigationTitle("QuizButton")
-        .navigationBarTitleDisplayMode(.large)
     }
 }
 

--- a/SoloDeveloperTraining/DUDesignSystemExample/Component/ComponentSegmentControlView.swift
+++ b/SoloDeveloperTraining/DUDesignSystemExample/Component/ComponentSegmentControlView.swift
@@ -13,49 +13,45 @@ struct ComponentSegmentControlView: View {
     @State private var trailing: String = "부동산"
 
     var body: some View {
-        VStack(spacing: TokenSpacing.lg) {
-            SegmentControl(leading: leading, trailing: trailing, selectedIndex: $selectedIndex)
-                .padding(.horizontal, TokenGrid.paddingSide)
-
-            VStack(alignment: .leading, spacing: TokenSpacing.sm) {
-                Text("선택된 탭: \(selectedIndex == 0 ? leading : trailing)")
-                    .duFont(.caption)
-                    .foregroundStyle(Color.gray400)
-
-                Picker("선택", selection: $selectedIndex) {
-                    Text(leading).tag(0)
-                    Text(trailing).tag(1)
-                }
-                .pickerStyle(.segmented)
+        VStack(spacing: 0) {
+            // MARK: - Preview Area
+            PreviewArea {
+                SegmentControl(leading: leading, trailing: trailing, selectedIndex: $selectedIndex)
+                    .frame(maxWidth: .infinity)
             }
-            .padding(.horizontal, TokenGrid.paddingSide)
 
-            VStack(spacing: TokenSpacing.xs) {
-                HStack {
-                    Text("앞")
-                        .duFont(.caption)
-                        .foregroundStyle(Color.gray400)
-                        .frame(width: 24)
-                    TextField("앞 텍스트", text: $leading)
-                        .textFieldStyle(.roundedBorder)
+            // MARK: - Controls
+            List {
+                Section("앞 텍스트") {
+                    HStack {
+                        TextField("앞 텍스트", text: $leading)
+                        if !leading.isEmpty {
+                            Button { leading = "" } label: {
+                                Image(systemName: "xmark.circle.fill")
+                                    .foregroundStyle(Color.gray400)
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
                 }
-                HStack {
-                    Text("뒤")
-                        .duFont(.caption)
-                        .foregroundStyle(Color.gray400)
-                        .frame(width: 24)
-                    TextField("뒤 텍스트", text: $trailing)
-                        .textFieldStyle(.roundedBorder)
+
+                Section("뒤 텍스트") {
+                    HStack {
+                        TextField("뒤 텍스트", text: $trailing)
+                        if !trailing.isEmpty {
+                            Button { trailing = "" } label: {
+                                Image(systemName: "xmark.circle.fill")
+                                    .foregroundStyle(Color.gray400)
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
                 }
             }
-            .padding(.horizontal, TokenGrid.paddingSide)
-
-            Spacer()
+            .scrollContentBackground(.hidden)
         }
-        .padding(.top, TokenSpacing.lg)
         .background(Color.beige200)
         .navigationTitle("SegmentControl")
-        .navigationBarTitleDisplayMode(.large)
     }
 }
 

--- a/SoloDeveloperTraining/DUDesignSystemExample/Component/ComponentSmallButtonView.swift
+++ b/SoloDeveloperTraining/DUDesignSystemExample/Component/ComponentSmallButtonView.swift
@@ -11,22 +11,29 @@ struct ComponentSmallButtonView: View {
     @State private var selectedType: SmallButton.SmallButtonType = .quiz
 
     var body: some View {
-        VStack(spacing: TokenSpacing.lg) {
-            SmallButton(type: selectedType) { }
-
-            Picker("타입", selection: $selectedType) {
-                Text("Quiz").tag(SmallButton.SmallButtonType.quiz)
-                Text("Setting").tag(SmallButton.SmallButtonType.setting)
+        VStack(spacing: 0) {
+            // MARK: - Preview Area
+            PreviewArea {
+                SmallButton(type: selectedType) { }
+                    .frame(maxWidth: .infinity, alignment: .center)
             }
-            .pickerStyle(.segmented)
-            .padding(.horizontal, TokenGrid.paddingSide)
 
-            Spacer()
+            // MARK: - Controls
+            List {
+                Section("타입") {
+                    Picker("타입", selection: $selectedType) {
+                        Text("Quiz").tag(SmallButton.SmallButtonType.quiz)
+                        Text("Setting").tag(SmallButton.SmallButtonType.setting)
+                    }
+                    .pickerStyle(.segmented)
+                }
+                .listRowBackground(Color.clear)
+                .listRowInsets(.init(top: 0, leading: 0, bottom: 0, trailing: 0))
+            }
+            .scrollContentBackground(.hidden)
         }
-        .padding(.top, TokenSpacing.lg)
         .background(Color.beige200)
         .navigationTitle("SmallButton")
-        .navigationBarTitleDisplayMode(.large)
     }
 }
 

--- a/SoloDeveloperTraining/DUDesignSystemExample/Component/ComponentStatusBarView.swift
+++ b/SoloDeveloperTraining/DUDesignSystemExample/Component/ComponentStatusBarView.swift
@@ -1,0 +1,59 @@
+//
+//  ComponentStatusBarView.swift
+//  DUDesignSystemExample
+//
+
+import SwiftUI
+import DUDesignSystem
+
+struct ComponentStatusBarView: View {
+
+    @State private var careerProgress: Double = 0.4
+    @State private var gold: Int = 20000
+    @State private var diamond: Int = 20
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // MARK: - Preview Area
+            PreviewArea {
+                StatusBar(
+                    imageName: "icon_coffee",
+                    careerNickname: "개발자 지망생 소피아",
+                    careerProgress: careerProgress,
+                    gold: gold,
+                    diamond: diamond
+                )
+                .frame(maxWidth: .infinity)
+            }
+
+            // MARK: - Controls
+            List {
+                Section("커리어 진행도") {
+                    Slider(value: $careerProgress, in: 0...1)
+                    Text("\(Int(careerProgress * 100))%")
+                        .foregroundStyle(Color.gray400)
+                }
+
+                Section("재화") {
+                    Stepper("골드: \(gold)", value: $gold, in: 0...99999, step: 1000)
+                    Stepper("다이아: \(diamond)", value: $diamond, in: 0...999)
+                }
+
+                Section {
+                    Text("상태 변경이나 유효성 검사는 비즈니스 로직이므로 예시 앱에는 반영되지 않아요.")
+                        .font(.caption)
+                        .foregroundStyle(Color.gray400)
+                }
+            }
+            .scrollContentBackground(.hidden)
+        }
+        .background(Color.beige200)
+        .navigationTitle("StatusBar")
+    }
+}
+
+#Preview {
+    NavigationStack {
+        ComponentStatusBarView()
+    }
+}

--- a/SoloDeveloperTraining/DUDesignSystemExample/Component/ComponentStatusBarView.swift
+++ b/SoloDeveloperTraining/DUDesignSystemExample/Component/ComponentStatusBarView.swift
@@ -9,8 +9,8 @@ import DUDesignSystem
 struct ComponentStatusBarView: View {
 
     @State private var careerProgress: Double = 0.4
-    @State private var gold: Int = 20000
-    @State private var diamond: Int = 20
+    @State private var gold: String = "20,000"
+    @State private var diamond: String = "20"
 
     var body: some View {
         VStack(spacing: 0) {
@@ -35,8 +35,16 @@ struct ComponentStatusBarView: View {
                 }
 
                 Section("재화") {
-                    Stepper("골드: \(gold)", value: $gold, in: 0...99999, step: 1000)
-                    Stepper("다이아: \(diamond)", value: $diamond, in: 0...999)
+                    HStack {
+                        Text("골드")
+                        TextField("골드", text: $gold)
+                            .multilineTextAlignment(.trailing)
+                    }
+                    HStack {
+                        Text("다이아")
+                        TextField("다이아", text: $diamond)
+                            .multilineTextAlignment(.trailing)
+                    }
                 }
 
                 Section {

--- a/SoloDeveloperTraining/DUDesignSystemExample/Component/ComponentTabbarItemView.swift
+++ b/SoloDeveloperTraining/DUDesignSystemExample/Component/ComponentTabbarItemView.swift
@@ -13,9 +13,9 @@ struct ComponentTabbarItemView: View {
     @State private var selectedState: TabbarItem.TabbarItemState = .default
 
     var body: some View {
-        List {
-            // MARK: - Preview
-            Section {
+        VStack(spacing: 0) {
+            // MARK: - Preview Area
+            PreviewArea {
                 HStack {
                     Spacer()
                     TabbarItem(assetName: assetName, text: text, state: selectedState) {
@@ -24,47 +24,45 @@ struct ComponentTabbarItemView: View {
                     .frame(width: 103)
                     Spacer()
                 }
-                .padding(.vertical, TokenSpacing.sm)
+                .frame(maxWidth: .infinity)
             }
-            .listRowBackground(Color.clear)
-            .listRowInsets(.init(top: 0, leading: 0, bottom: 0, trailing: 0))
 
-            // MARK: - 텍스트
-            Section("텍스트") {
-                HStack {
-                    TextField("텍스트 입력", text: $text)
-                    if !text.isEmpty {
-                        Button { text = "" } label: {
-                            Image(systemName: "xmark.circle.fill")
-                                .foregroundStyle(Color.gray400)
+            // MARK: - Controls
+            List {
+                Section("텍스트") {
+                    HStack {
+                        TextField("텍스트 입력", text: $text)
+                        if !text.isEmpty {
+                            Button { text = "" } label: {
+                                Image(systemName: "xmark.circle.fill")
+                                    .foregroundStyle(Color.gray400)
+                            }
+                            .buttonStyle(.plain)
                         }
-                        .buttonStyle(.plain)
+                    }
+                }
+
+                Section("상태") {
+                    Picker("상태", selection: $selectedState) {
+                        Text("Default").tag(TabbarItem.TabbarItemState.default)
+                        Text("Selected").tag(TabbarItem.TabbarItemState.selected)
+                    }
+                    .pickerStyle(.segmented)
+                }
+                .listRowBackground(Color.clear)
+                .listRowInsets(.init(top: 0, leading: 0, bottom: 0, trailing: 0))
+
+                Section("이미지명") {
+                    Picker("이미지명", selection: $assetName) {
+                        Text("work").tag("work")
+                        Text("mission").tag("mission")
+                        Text("skill").tag("skill")
+                        Text("shop").tag("shop")
                     }
                 }
             }
-
-            // MARK: - 상태
-            Section("상태") {
-                Picker("상태", selection: $selectedState) {
-                    Text("Default").tag(TabbarItem.TabbarItemState.default)
-                    Text("Selected").tag(TabbarItem.TabbarItemState.selected)
-                }
-                .pickerStyle(.segmented)
-            }
-            .listRowBackground(Color.clear)
-            .listRowInsets(.init(top: 0, leading: 0, bottom: 0, trailing: 0))
-
-            // MARK: - 이미지명
-            Section("이미지명") {
-                Picker("이미지명", selection: $assetName) {
-                    Text("work").tag("work")
-                    Text("mission").tag("mission")
-                    Text("skill").tag("skill")
-                    Text("shop").tag("shop")
-                }
-            }
+            .scrollContentBackground(.hidden)
         }
-        .scrollContentBackground(.hidden)
         .background(Color.beige200)
         .navigationTitle("TabbarItem")
     }

--- a/SoloDeveloperTraining/DUDesignSystemExample/Component/ComponentTabbarView.swift
+++ b/SoloDeveloperTraining/DUDesignSystemExample/Component/ComponentTabbarView.swift
@@ -11,16 +11,22 @@ struct ComponentTabbarView: View {
     @State private var selectedIndex: Int = 0
 
     var body: some View {
-        VStack {
-            Text("선택된 탭: \(Tabbar.items[selectedIndex].text)")
-                .duFont(.caption)
-                .foregroundStyle(Color.gray400)
+        VStack(spacing: 0) {
+            // MARK: - Preview Area
+            PreviewArea {
+                Tabbar(selectedIndex: $selectedIndex)
+                    .frame(maxWidth: .infinity)
+            }
 
-            Tabbar(selectedIndex: $selectedIndex)
-            Spacer()
+            // MARK: - Controls
+            List {
+                Section("선택된 탭") {
+                    Text(Tabbar.items[selectedIndex].text)
+                        .foregroundStyle(Color.gray400)
+                }
+            }
+            .scrollContentBackground(.hidden)
         }
-        .padding(TokenGrid.paddingSide)
-        .scrollContentBackground(.hidden)
         .background(Color.beige200)
         .navigationTitle("Tabbar")
     }

--- a/SoloDeveloperTraining/DUDesignSystemExample/Component/ComponentTextButtonView.swift
+++ b/SoloDeveloperTraining/DUDesignSystemExample/Component/ComponentTextButtonView.swift
@@ -13,70 +13,67 @@ struct ComponentTextButtonView: View {
     @State private var selectedSize: TextButton.TextButtonSize = .large
     @State private var selectedState: TextButton.TextButtonState = .default
     @State private var showDiamond: Bool = false
-    var body: some View {
-        List {
-            // MARK: - Preview
-            Section {
-                TextButton(text: text, type: selectedType, size: selectedSize, state: selectedState, showDiamond: showDiamond) { }
-                    .padding(.vertical, TokenSpacing.lg)
-            }
-            .listRowBackground(Color.clear)
-            .listRowInsets(.init(top: 0, leading: 0, bottom: 0, trailing: 0))
 
-            // MARK: - 텍스트
-            Section("텍스트") {
-                HStack {
-                    TextField("텍스트 입력", text: $text)
-                    if !text.isEmpty {
-                        Button { text = "" } label: {
-                            Image(systemName: "xmark.circle.fill")
-                                .foregroundStyle(Color.gray400)
+    var body: some View {
+        VStack(spacing: 0) {
+            // MARK: - Preview Area
+            PreviewArea {
+                TextButton(text: text, type: selectedType, size: selectedSize, state: selectedState, showDiamond: showDiamond) { }
+                    .frame(maxWidth: .infinity)
+            }
+
+            // MARK: - Controls
+            List {
+                Section("텍스트") {
+                    HStack {
+                        TextField("텍스트 입력", text: $text)
+                        if !text.isEmpty {
+                            Button { text = "" } label: {
+                                Image(systemName: "xmark.circle.fill")
+                                    .foregroundStyle(Color.gray400)
+                            }
+                            .buttonStyle(.plain)
                         }
-                        .buttonStyle(.plain)
                     }
                 }
-            }
 
-            // MARK: - 타입
-            Section("타입") {
-                Picker("타입", selection: $selectedType) {
-                    Text("Primary").tag(TextButton.TextButtonType.primary)
-                    Text("Secondary").tag(TextButton.TextButtonType.secondary)
+                Section("타입") {
+                    Picker("타입", selection: $selectedType) {
+                        Text("Primary").tag(TextButton.TextButtonType.primary)
+                        Text("Secondary").tag(TextButton.TextButtonType.secondary)
+                    }
+                    .pickerStyle(.segmented)
                 }
-                .pickerStyle(.segmented)
-            }
-            .listRowBackground(Color.clear)
-            .listRowInsets(.init(top: 0, leading: 0, bottom: 0, trailing: 0))
+                .listRowBackground(Color.clear)
+                .listRowInsets(.init(top: 0, leading: 0, bottom: 0, trailing: 0))
 
-            // MARK: - 크기
-            Section("크기") {
-                Picker("크기", selection: $selectedSize) {
-                    Text("Large").tag(TextButton.TextButtonSize.large)
-                    Text("Medium").tag(TextButton.TextButtonSize.medium)
+                Section("크기") {
+                    Picker("크기", selection: $selectedSize) {
+                        Text("Large").tag(TextButton.TextButtonSize.large)
+                        Text("Medium").tag(TextButton.TextButtonSize.medium)
+                    }
+                    .pickerStyle(.segmented)
                 }
-                .pickerStyle(.segmented)
-            }
-            .listRowBackground(Color.clear)
-            .listRowInsets(.init(top: 0, leading: 0, bottom: 0, trailing: 0))
+                .listRowBackground(Color.clear)
+                .listRowInsets(.init(top: 0, leading: 0, bottom: 0, trailing: 0))
 
-            // MARK: - 상태
-            Section("상태") {
-                Picker("상태", selection: $selectedState) {
-                    Text("Default").tag(TextButton.TextButtonState.default)
-                    Text("Disabled").tag(TextButton.TextButtonState.disabled)
-                    Text("Locked").tag(TextButton.TextButtonState.locked)
+                Section("상태") {
+                    Picker("상태", selection: $selectedState) {
+                        Text("Default").tag(TextButton.TextButtonState.default)
+                        Text("Disabled").tag(TextButton.TextButtonState.disabled)
+                        Text("Locked").tag(TextButton.TextButtonState.locked)
+                    }
+                    .pickerStyle(.segmented)
                 }
-                .pickerStyle(.segmented)
-            }
-            .listRowBackground(Color.clear)
-            .listRowInsets(.init(top: 0, leading: 0, bottom: 0, trailing: 0))
+                .listRowBackground(Color.clear)
+                .listRowInsets(.init(top: 0, leading: 0, bottom: 0, trailing: 0))
 
-            // MARK: - 다이아몬드
-            Section("다이아몬드") {
-                Toggle("showDiamond", isOn: $showDiamond)
+                Section("다이아몬드") {
+                    Toggle("showDiamond", isOn: $showDiamond)
+                }
             }
+            .scrollContentBackground(.hidden)
         }
-        .scrollContentBackground(.hidden)
         .background(Color.beige200)
         .navigationTitle("TextButton")
         .navigationSubtitle("누르고 있으면 pressed 상태를 확인할 수 있어요")

--- a/SoloDeveloperTraining/DUDesignSystemExample/Component/ComponentToastView.swift
+++ b/SoloDeveloperTraining/DUDesignSystemExample/Component/ComponentToastView.swift
@@ -1,0 +1,47 @@
+//
+//  ComponentToastView.swift
+//  DUDesignSystemExample
+//
+
+import SwiftUI
+import DUDesignSystem
+
+struct ComponentToastView: View {
+
+    @State private var message: String = "토스트 안내 메시지입니다."
+
+    var body: some View {
+        List {
+            // MARK: - Preview
+            Section {
+                Toast(message: message)
+                    .padding(.vertical, TokenSpacing.lg)
+            }
+            .listRowBackground(Color.clear)
+            .listRowInsets(.init(top: 0, leading: TokenSpacing.md, bottom: 0, trailing: TokenSpacing.md))
+
+            // MARK: - 메시지
+            Section("메시지") {
+                HStack {
+                    TextField("메시지 입력", text: $message)
+                    if !message.isEmpty {
+                        Button { message = "" } label: {
+                            Image(systemName: "xmark.circle.fill")
+                                .foregroundStyle(Color.gray400)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+            }
+        }
+        .scrollContentBackground(.hidden)
+        .background(Color.beige200)
+        .navigationTitle("Toast")
+    }
+}
+
+#Preview {
+    NavigationStack {
+        ComponentToastView()
+    }
+}

--- a/SoloDeveloperTraining/DUDesignSystemExample/Component/ComponentToastView.swift
+++ b/SoloDeveloperTraining/DUDesignSystemExample/Component/ComponentToastView.swift
@@ -11,30 +11,30 @@ struct ComponentToastView: View {
     @State private var message: String = "토스트 안내 메시지입니다."
 
     var body: some View {
-        List {
-            // MARK: - Preview
-            Section {
+        VStack(spacing: 0) {
+            // MARK: - Preview Area
+            PreviewArea {
                 Toast(message: message)
-                    .padding(.vertical, TokenSpacing.lg)
+                    .frame(maxWidth: .infinity)
             }
-            .listRowBackground(Color.clear)
-            .listRowInsets(.init(top: 0, leading: TokenSpacing.md, bottom: 0, trailing: TokenSpacing.md))
 
-            // MARK: - 메시지
-            Section("메시지") {
-                HStack {
-                    TextField("메시지 입력", text: $message)
-                    if !message.isEmpty {
-                        Button { message = "" } label: {
-                            Image(systemName: "xmark.circle.fill")
-                                .foregroundStyle(Color.gray400)
+            // MARK: - Controls
+            List {
+                Section("메시지") {
+                    HStack {
+                        TextField("메시지 입력", text: $message)
+                        if !message.isEmpty {
+                            Button { message = "" } label: {
+                                Image(systemName: "xmark.circle.fill")
+                                    .foregroundStyle(Color.gray400)
+                            }
+                            .buttonStyle(.plain)
                         }
-                        .buttonStyle(.plain)
                     }
                 }
             }
+            .scrollContentBackground(.hidden)
         }
-        .scrollContentBackground(.hidden)
         .background(Color.beige200)
         .navigationTitle("Toast")
     }

--- a/SoloDeveloperTraining/DUDesignSystemExample/Component/PreviewArea.swift
+++ b/SoloDeveloperTraining/DUDesignSystemExample/Component/PreviewArea.swift
@@ -1,0 +1,42 @@
+//
+//  PreviewArea.swift
+//  DUDesignSystemExample
+//
+
+import SwiftUI
+import DUDesignSystem
+
+struct PreviewArea<Content: View>: View {
+
+    private let content: Content
+
+    init(@ViewBuilder content: () -> Content) {
+        self.content = content()
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: TokenSpacing.sm) {
+            Text("Preview")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(Color.previewLabel)
+                .padding(.horizontal, TokenSpacing.md)
+
+            content
+        }
+        .padding(.vertical, TokenSpacing.md)
+        .background(Color.previewBackground)
+        .clipShape(RoundedRectangle(cornerRadius: TokenRadius.sm))
+        .padding(.horizontal, TokenSpacing.md)
+        .padding(.top, TokenSpacing.md)
+        .padding(.bottom, TokenSpacing.sm)
+    }
+}
+
+// MARK: - Example App 전용 컬러 (DUDesignSystem 토큰 미사용)
+
+private extension Color {
+    /// 예시 앱 프리뷰 영역 배경 — 쿨 그레이 계열로 디자인 시스템 베이지/오렌지 계열과 충돌 없음
+    static let previewBackground = Color(red: 226/255, green: 232/255, blue: 240/255)
+    /// 프리뷰 영역 레이블
+    static let previewLabel = Color(red: 148/255, green: 163/255, blue: 184/255)
+}


### PR DESCRIPTION
## 연관된 이슈

- [#KAN-82](https://devvup.atlassian.net/jira/software/projects/KAN/boards/1/backlog?selectedIssue=KAN-82)

## 작업 내용 및 고민 내용

Figma 디자인 시스템 기준으로 InputField / Toast / Popup / Bar 컴포넌트 구현

### 추가된 컴포넌트

#### Inputs
- `InputField` — 텍스트 입력 필드. state(default/error/success) 지원, 포커스 시 높이 고정으로 레이아웃 변화 방지

#### Feedback
- `Toast` — 안내 메시지 토스트. 좌우 24pt 패딩 자체 포함, dim 그림자 적용

#### Dialogs
- `Popup` — 팝업 다이얼로그. type(notice/confirm/reward) 세 가지 지원

#### Bars
- `ProgressBar` — 진행 바. type(default/career/mission/time) 네 가지 지원
- `GameToolBar` — 게임 플레이 중 상단 툴바. 피버 단계(0~3)별 바 색상 변화, 아이템 개수 표시
- `StatusBar` — 홈 화면 상태 바. 커리어 이미지 + 닉네임 + 진행바 + 금/다이아 재화 표시

---

### 사용법

#### InputField
```swift
@State var text: String = ""

InputField(text: $text, placeholder: "닉네임을 입력해주세요")
InputField(text: $text, placeholder: "닉네임을 입력해주세요", state: .error(message: "닉네임은 1자 이상 입력해주세요."))
InputField(text: $text, placeholder: "닉네임을 입력해주세요", state: .success)
```

#### Toast
```swift
Toast(message: "토스트 안내 메시지입니다.")
```

#### Popup
```swift
// 단일 닫기 버튼
Popup(type: .notice(
    title: "팝업 타이틀",
    body: "팝업 내용",
    buttonText: "닫기",
    action: { }
))

// 취소 / 확인 버튼
Popup(type: .confirm(
    title: "팝업 타이틀",
    body: "팝업 내용",
    cancelText: "취소",
    confirmText: "구매",
    cancelAction: { },
    confirmAction: { }
))

// 리워드 획득 + 닫기 버튼
Popup(type: .reward(
    title: "팝업 타이틀",
    body: "팝업 내용",
    rewardLeadingText: "획득한 다이아 : ",
    rewardIcon: .diamond,
    rewardTrailingText: "20",
    buttonText: "닫기",
    action: { }
))
```

#### ProgressBar
```swift
// 기본
ProgressBar(progress: 0.6)

// 커리어
ProgressBar(progress: 0.4, type: .career(
    currentText: "20,000",
    currentSubText: "누적",
    goalText: "20,000",
    goalSubText: "개발자 지망생"
))

// 미션
ProgressBar(progress: 0.9, type: .mission(current: 9, total: 10))

// 타이머
ProgressBar(progress: 0.3, type: .time(
    currentStep: 1,
    totalStep: 3,
    timeText: "남은 시간 30s"
))
```

#### GameToolBar
```swift
GameToolBar(
    feverStage: 2,
    feverProgress: 0.5,
    feverMultiplier: 2.0,
    coffeeCount: 5,
    energyDrinkCount: 3,
    onClose: { },
    onCoffee: { },
    onEnergyDrink: { }
)
```

#### StatusBar
```swift
StatusBar(
    imageName: "career_laptop_owner",
    careerNickname: "개발자 지망생 소피아",
    careerProgress: 0.4,
    gold: "20,000",
    diamond: "20"
)
```

---

### 주요 설계 결정

**1. InputField 포커스 시 레이아웃 고정 — `.frame(height: 24)`**

```swift
// ❌ 검토했다가 제외 — placeholder opacity만 제어
.opacity(text.isEmpty && !isFocused ? 1 : 0)
// 포커스 시 TextField 내부 폰트 렌더링 차이로 ZStack 높이가 미세하게 변하는 문제 발생

// ✅ 채택 — ZStack 높이 고정
ZStack(alignment: .leading) {
    Text(placeholder)...
    TextField("", text: $text)...
}
.frame(height: 24)
```

SwiftUI의 `TextField`는 포커스 상태에 따라 내부 높이가 미세하게 달라지는 이슈가 있습니다. ZStack에 고정 높이를 지정해 포커스 여부와 무관하게 레이아웃이 안정적으로 유지되도록 했습니다.

**2. PreviewArea — 예시앱 공통 프리뷰 컴포넌트 추출**

기존에 각 Component*View마다 인라인으로 구현되어 있던 프리뷰 영역을 `PreviewArea` 제네릭 컴포넌트로 분리했습니다. List의 `insetGrouped` 스타일이 강제하는 큰 코너 반경 문제를 해결하기 위해 프리뷰 영역을 List 외부 VStack으로 분리했으며, 디자인 토큰 색상과 충돌하지 않는 (`#E2E8F0`)를 사용했습니다.

프리뷰 영역 자체에는 패딩을 넣지 않아, 컴포넌트가 영역을 가득 채우면 fill 레이아웃임을 확인할 수 있고, 컴포넌트가 영역 안에서 떨어져 보이면 컴포넌트 내부에 자체 패딩이 있음을 직관적으로 파악할 수 있습니다
예: `Toast`는 좌우 24pt 패딩을 자체 포함하므로 프리뷰에서 양옆이 띄워져 보입니다.)

---

### Example 앱

- 기존 11개 컴포넌트 예제 화면 전체에 `PreviewArea` 적용 및 레이아웃 통일
- InputField, Toast, Popup, ProgressBar, GameToolBar, StatusBar 예제 화면 추가
- 각 예제 화면에서 Picker / Slider / Stepper로 모든 프로퍼티를 실시간 조합 확인 가능

> 해당 브랜치에서 `SoloDeveloperTraining` 워크스페이스의 Example 앱을 빌드해 Component 섹션에서 직접 확인 부탁드립니다.
