### PR TITLE
계정 이전을 위해 번들 ID와 Signing 설정을 수동으로 변경합니다.

### DIFF
--- a/SoloDeveloperTraining/SoloDeveloperTraining.xcodeproj/project.pbxproj
+++ b/SoloDeveloperTraining/SoloDeveloperTraining.xcodeproj/project.pbxproj
@@ -636,7 +636,7 @@
 		};
 		08267F372F0D06BE005A0066 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = B4C100022FCFE2A000000001 /* SoloDeveloperTraining/App/Config/Release.xcconfig */;
+			baseConfigurationReference = B4C100012FCFE2A000000001 /* SoloDeveloperTraining/App/Config/Debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = app_icon_release;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;

--- a/SoloDeveloperTraining/SoloDeveloperTraining.xcodeproj/project.pbxproj
+++ b/SoloDeveloperTraining/SoloDeveloperTraining.xcodeproj/project.pbxproj
@@ -636,7 +636,7 @@
 		};
 		08267F372F0D06BE005A0066 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = B4C100012FCFE2A000000001 /* SoloDeveloperTraining/App/Config/Debug.xcconfig */;
+			baseConfigurationReference = B4C100022FCFE2A000000001 /* SoloDeveloperTraining/App/Config/Release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = app_icon_release;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;

--- a/SoloDeveloperTraining/SoloDeveloperTraining.xcodeproj/project.pbxproj
+++ b/SoloDeveloperTraining/SoloDeveloperTraining.xcodeproj/project.pbxproj
@@ -641,9 +641,11 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = app_icon_release;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = SoloDeveloperTraining/App/SoloDeveloperTraining.entitlements;
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = B3PWYBKFUK;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = QBLK6726G4;
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -664,6 +666,8 @@
 				MARKETING_VERSION = 1.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = kr.codesquad.boostcamp10.SoloDeveloperTraining;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = development_provisioning;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
@@ -685,9 +689,11 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = app_icon_release;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = SoloDeveloperTraining/App/SoloDeveloperTraining.entitlements;
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = B3PWYBKFUK;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = QBLK6726G4;
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -708,6 +714,8 @@
 				MARKETING_VERSION = 1.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = kr.codesquad.boostcamp10.SoloDeveloperTraining;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = distribution_provisioning;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
@@ -727,9 +735,11 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = QBLK6726G4;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -742,8 +752,10 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 0.0.1;
-				PRODUCT_BUNDLE_IDENTIFIER = com.teamDevup.DUDesignSystem;
+				PRODUCT_BUNDLE_IDENTIFIER = com.devup.DUDesignSystem;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = design_example_development_provisioning;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
@@ -763,9 +775,11 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = QBLK6726G4;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -778,8 +792,10 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 0.0.1;
-				PRODUCT_BUNDLE_IDENTIFIER = com.teamDevup.DUDesignSystem;
+				PRODUCT_BUNDLE_IDENTIFIER = com.devup.DUDesignSystem;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = design_example_distribution_provisioning;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
@@ -801,9 +817,11 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = app_icon_dev;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = B3PWYBKFUK;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = QBLK6726G4;
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -824,8 +842,10 @@
 				);
 				MARKETING_VERSION = 1.0;
 				OTHER_SWIFT_FLAGS = "-DDEV_BUILD";
-				PRODUCT_BUNDLE_IDENTIFIER = kr.codesquad.boostcamp10.SoloDeveloperTraining.dev;
+				PRODUCT_BUNDLE_IDENTIFIER = com.devup.dev;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = dev_development_provisioning;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
@@ -847,9 +867,11 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = app_icon_dev;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = B3PWYBKFUK;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = QBLK6726G4;
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -870,8 +892,10 @@
 				);
 				MARKETING_VERSION = 1.0;
 				OTHER_SWIFT_FLAGS = "-DDEV_BUILD";
-				PRODUCT_BUNDLE_IDENTIFIER = kr.codesquad.boostcamp10.SoloDeveloperTraining.dev;
+				PRODUCT_BUNDLE_IDENTIFIER = com.devup.dev;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = dev_distribution_provisioning;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;

--- a/SoloDeveloperTraining/SoloDeveloperTraining/public/.well-known/apple-app-site-association
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/public/.well-known/apple-app-site-association
@@ -3,7 +3,11 @@
     "apps": [],
     "details": [
       {
-        "appID": "B3PWYBKFUK.kr.codesquad.boostcamp10.SoloDeveloperTraining",
+        "appID": "QBLK6726G4.kr.codesquad.boostcamp10.SoloDeveloperTraining",
+        "paths": ["*"]
+      },
+      {
+        "appID": "QBLK6726G4.com.devup.dev",
         "paths": ["*"]
       }
     ]


### PR DESCRIPTION
## 연관된 이슈

- [KAN-95](https://devvup.atlassian.net/browse/KAN-95)

## 작업 내용 및 고민 내용
### 앱 Bundle ID 변경 
- 아래 타깃 앱에 대해 이전 계정 귀속 문제로 프로비저닝 프로파일 생성에 필요한 번들 id 지정에 문제가 있었습니다. 
- 이전 번들 id 기준,
  - `kr.codesquad.boostcamp10.SoloDeveloperTraining.dev`
  - `com.teamDevup.DUDesignSystem`
- 해당 앱은 이전 배포 이력이나 관련 데이터를 이전해 올 필요가 없으므로, 간단히 번들 id를 변경하여 해결했습니다.
  - `kr.codesquad.boostcamp10.SoloDeveloperTraining.dev` -> `com.devup.dev`
  - `com.teamDevup.DUDesignSystem` -> `com.devup.DUDesignSystem`

### Automatic Signing 해제 및 수동 설정
- 현재 개발자 계정을 '개인 계정'으로 소유하고 있어, 팀원들이 Automatic manger Signing 기능을 사용할 수 없었습니다.
- 따라서 해당 설정 값을 해제하고 수동으로 프로비저닝 파일을 추가해야합니다.
- 프로비저닝 및 인증서 파일은 디스코드 채팅으로 공유드렸습니다.
  - 프로비저닝 파일은 총 6개로 3개의 타깃에 대해 각각 2가지 종류(development, distribution)에 맞는 프로비저닝 파일로 구성됩니다.

### Dev 타깃에서 카카오톡 개발용 테스트 메시지를 눌렀을 때 운영 앱이 열리는 현상 유지
- 현재 로컬에서 운영 앱과 Dev 앱을 둘 다 설치한 상태에서, Dev 앱으로 전송한 카카오톡 개발용 테스트 메시지를 누르면 Dev 앱이 아니라 운영 앱이 열리는 상태이며, 처음에는 버그라고 생각했으나 현 상황을 유지하도록 결정했습니다.

  - 먼저 해당 문제의 원인은 운영 타깃도 Debug 빌드에서는 Debug.xcconfig 값을 사용하기 때문입니다.
  - 현재 Debug.xcconfig에는 개발용 카카오 앱 키와 URL scheme이 들어가 있으므로, 운영 앱을 Debug로 빌드하면 운영 앱도 개발용 카카오 scheme을 함께 등록하게 됩니다. 결과적으로 기기에 아래처럼 같은 scheme을 가진 앱이 2개 설치됩니다.
    - 운영 앱 Debug 빌드: 개발용 카카오 scheme 등록
    - Dev 앱 Debug 빌드: 개발용 카카오 scheme 등록

  - 이 상태에서 카카오톡 개발용 테스트 메시지를 누르면 iOS가 어떤 앱을 열지 안정적으로 보장하지 못하고, 현재는 운영 앱이 열리는 현상이 발생합니다. 운영 앱을 삭제하면 Dev 앱이 정상적으로 열리는 이유도 이 때문입니다. 해결 방법으로는 다음 선택지가 있었습니다.
  
  ```swift
  1. 운영/Dev 타깃별로 xcconfig를 분리
  2. 하나의 xcconfig 안에 운영/개발 카카오 스킴 값을 모두 두고 타깃별로 매핑
  3. 운영 타깃은 항상 Release 카카오 설정을 바라보게 변경
  ```

다만 이 문제는 로컬 Debug 빌드에서 운영 앱과 Dev 앱을 동시에 설치했을 때만 발생하는 테스트 환경 이슈입니다.
또 운영 타깃이 Debug 빌드에서 Release 설정을 보도록 바꾸면, AdMob 테스트 광고 설정과 충돌할 수 있습니다. 물론 현재 저희 팀원 모두의 기기를 테스트 기기로 등록했기 때문에 test 광고가 송출될 가능성이 높지만, 구조적으로 안전하게 보장하는게 좋다고 생각했습니다.

따라서 현재는 설정을 변경하지 않고 유지했습니다. 로컬에서 카카오톡 개발용 테스트 메시지를 확인할 필요가 있을 경우는 운영 앱을 삭제한 뒤 Dev 앱만 설치한 상태에서 테스트 해주시길 바랍니다.

## 리뷰 요구사항
- 실기기 및 시뮬레이터 빌드에 이상이 없는지 확인부탁드립니다.
