### PR TITLE
광고 시청 후 시나리오 재선택 기능을 추가합니다.

### DIFF
--- a/SoloDeveloperTraining/SoloDeveloperTraining/GameCore/Models/Scenarios/ScenarioProgress.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/GameCore/Models/Scenarios/ScenarioProgress.swift
@@ -44,6 +44,12 @@ struct ScenarioProgress {
         currentPageIndex += 1
     }
 
+    /// 이전 선택 페이지로 이동 (재선택용)
+    mutating func moveToPreviousChoicePage() {
+        guard currentPageIndex > 0 else { return }
+        currentPageIndex -= 1
+    }
+
     /// 시나리오 완료
     mutating func completeScenario() {
         guard let career = currentCareer else { return }

--- a/SoloDeveloperTraining/SoloDeveloperTraining/GameCore/Models/Scenarios/ScenarioProgress.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/GameCore/Models/Scenarios/ScenarioProgress.swift
@@ -44,12 +44,6 @@ struct ScenarioProgress {
         currentPageIndex += 1
     }
 
-    /// 이전 선택 페이지로 이동 (재선택용)
-    mutating func moveToPreviousChoicePage() {
-        guard currentPageIndex > 0 else { return }
-        currentPageIndex -= 1
-    }
-
     /// 시나리오 완료
     mutating func completeScenario() {
         guard let career = currentCareer else { return }

--- a/SoloDeveloperTraining/SoloDeveloperTraining/GameCore/Models/Systems/ScenarioManager.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/GameCore/Models/Systems/ScenarioManager.swift
@@ -64,9 +64,14 @@ final class ScenarioManager {
 
     /// 선택 취소 후 이전 선택 페이지로 이동 (재선택용)
     func reselectChoice() {
-        guard let career = currentScenario?.career else { return }
+        guard let career = currentScenario?.career,
+              let scenario = currentScenario,
+              let choiceIndex = scenario.pages.firstIndex(where: {
+                  if case .choice = $0.pageType { return true }
+                  return false
+              }) else { return }
         record.choiceHistory.removeValue(forKey: career)
-        record.scenarioProgress.moveToPreviousChoicePage()
+        record.scenarioProgress.currentPageIndex = choiceIndex
     }
 
     /// 시나리오 완료

--- a/SoloDeveloperTraining/SoloDeveloperTraining/GameCore/Models/Systems/ScenarioManager.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/GameCore/Models/Systems/ScenarioManager.swift
@@ -62,6 +62,13 @@ final class ScenarioManager {
         record.scenarioProgress.moveToNextPage()
     }
 
+    /// 선택 취소 후 이전 선택 페이지로 이동 (재선택용)
+    func reselectChoice() {
+        guard let career = currentScenario?.career else { return }
+        record.choiceHistory.removeValue(forKey: career)
+        record.scenarioProgress.moveToPreviousChoicePage()
+    }
+
     /// 시나리오 완료
     func completeScenario() {
         record.scenarioProgress.completeScenario()

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Advertisement/AdService.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Advertisement/AdService.swift
@@ -20,7 +20,7 @@ final class AdService {
     private let factory: AdFactory
     private var loadedAds: [AdType: AdUnit] = [:]
     private var loadingTasks: [AdType: Task<AdUnit?, Never>] = [:]
-    private var isShowing = false
+    private(set) var isShowing = false
 
     init(factory: AdFactory) {
         self.factory = factory

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/MainView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/MainView.swift
@@ -608,6 +608,7 @@ private extension MainView {
     }
 
     func checkOfflineReward() async {
+        guard !AdService.shared.isShowing else { return }
         guard !hasCheckedOfflineReward else { return }
 
         hasCheckedOfflineReward = true

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Scenario/ScenarioStoryView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Scenario/ScenarioStoryView.swift
@@ -17,6 +17,7 @@ struct ScenarioStoryView: View {
     @State private var currentPageIndex: Int
     @State private var selected: String = ""
     @State private var finalEnding: Ending? = nil
+    @State private var isShowingAd = false
 
     // 공유하기
     @State private var isShareSheetPresented = false
@@ -146,7 +147,17 @@ private extension ScenarioStoryView {
             )
         case .result:
             EventButton(type: .reselect(onReselect: {
-                // TODO: 재선택 로직 추가
+                guard !isShowingAd else { return }
+                isShowingAd = true
+                Task {
+                    let success = await AdService.shared.showAdWithResult(.interstitial)
+                    isShowingAd = false
+                    if success {
+                        selected = ""
+                        manager.reselectChoice()
+                        currentPageIndex = manager.currentPageIndex
+                    }
+                }
             }, onComplete: {
                 handleNextTap()
             }))

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Scenario/ScenarioStoryView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Scenario/ScenarioStoryView.swift
@@ -154,8 +154,10 @@ private extension ScenarioStoryView {
                     isShowingAd = false
                     if success {
                         selected = ""
-                        manager.reselectChoice()
-                        currentPageIndex = manager.currentPageIndex
+                        withAnimation(.spring(response: 0.5, dampingFraction: 0.8)) {
+                            manager.reselectChoice()
+                            currentPageIndex = manager.currentPageIndex
+                        }
                     }
                 }
             }, onComplete: {


### PR DESCRIPTION
## 연관된 이슈

[KAN-54](https://devvup.atlassian.net/browse/KAN-54)

## 작업 내용

### 광고 시청 후 선택지 재선택 기능 구현

선택형 이벤트 시나리오에서 광고를 1회 시청하면 선택지를 다시 선택할 수 있는 기능을 구현했습니다.  
반복 시청 시 매번 재선택이 가능하며, '완료' 버튼으로 이벤트 화면을 닫을 수 있습니다.

#### ScenarioManager — 재선택 메서드 추가
- `reselectChoice()` 메서드 추가
- 재선택 시 해당 커리어의 `choiceHistory` 기록 제거
- 단순 인덱스 변경 방식이 아닌 시나리오 내 `.choice` 페이지를 직접 탐색하여 이동

#### ScenarioStoryView — 재선택 버튼 액션 연결
- `.result` 페이지의 `onReselect` 클로저에 광고 시청 및 재선택 로직 연결
- 광고 시청 성공 시 선택 상태 초기화 후 `.choice` 페이지로 복귀
- 중복 광고 호출 방지를 위한 `isShowingAd` 플래그 추가
- 페이지 복귀 시 애니메이션 적용

### 광고 시청 중 오프라인 보상 팝업 방지

전면 광고 시청 시 iOS가 앱을 백그라운드로 전환하면서 오프라인 보상 팝업이 잘못 노출되는 문제를 수정했습니다.

- `AdService.isShowing`을 `private(set)`으로 변경하여 외부 접근 허용
- `MainView.checkOfflineReward()`에서 광고 시청 중일 때 오프라인 보상 체크 스킵

## 스크린샷

https://github.com/user-attachments/assets/5beafd10-a6b0-4fef-bc83-025f08d11fb0
