### PR TITLE
딥링크 공유 추적을 위한 URL 파라미터 추가 및 AppsFlyer SDK를 연동합니다.

### DIFF
--- a/SoloDeveloperTraining.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SoloDeveloperTraining.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,168 @@
+{
+  "originHash" : "9611551d17b1e56d863b3d9607bf84e02dba95573edd972777597dc3ef5dd9b7",
+  "pins" : [
+    {
+      "identity" : "abseil-cpp-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/abseil-cpp-binary.git",
+      "state" : {
+        "revision" : "bbe8b69694d7873315fd3a4ad41efe043e1c07c5",
+        "version" : "1.2024072200.0"
+      }
+    },
+    {
+      "identity" : "alamofire",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Alamofire/Alamofire.git",
+      "state" : {
+        "revision" : "7595cbcf59809f9977c5f6378500de2ad73b7ddb",
+        "version" : "5.12.0"
+      }
+    },
+    {
+      "identity" : "app-check",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/app-check.git",
+      "state" : {
+        "revision" : "61b85103a1aeed8218f17c794687781505fbbef5",
+        "version" : "11.2.0"
+      }
+    },
+    {
+      "identity" : "appsflyerframework",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/AppsFlyerSDK/AppsFlyerFramework",
+      "state" : {
+        "revision" : "d72189b737f88108f87f0ad95fa7551dc241d320",
+        "version" : "7.0.0"
+      }
+    },
+    {
+      "identity" : "firebase-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/firebase-ios-sdk.git",
+      "state" : {
+        "revision" : "8d5b4189f1f482df8d5c58c9985ea70491ef5382",
+        "version" : "12.14.0"
+      }
+    },
+    {
+      "identity" : "google-ads-on-device-conversion-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/googleads/google-ads-on-device-conversion-ios-sdk",
+      "state" : {
+        "revision" : "9bfcc6cf435b2e7c5562c1900b8680c594fa9a64",
+        "version" : "3.6.0"
+      }
+    },
+    {
+      "identity" : "googleappmeasurement",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleAppMeasurement.git",
+      "state" : {
+        "revision" : "219e564a8510e983e675c94f77f7f7c50049f22d",
+        "version" : "12.14.0"
+      }
+    },
+    {
+      "identity" : "googledatatransport",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleDataTransport.git",
+      "state" : {
+        "revision" : "617af071af9aa1d6a091d59a202910ac482128f9",
+        "version" : "10.1.0"
+      }
+    },
+    {
+      "identity" : "googleutilities",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleUtilities.git",
+      "state" : {
+        "revision" : "60da361632d0de02786f709bdc0c4df340f7613e",
+        "version" : "8.1.0"
+      }
+    },
+    {
+      "identity" : "grpc-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/grpc-binary.git",
+      "state" : {
+        "revision" : "75b31c842f664a0f46a2e590a570e370249fd8f6",
+        "version" : "1.69.1"
+      }
+    },
+    {
+      "identity" : "gtm-session-fetcher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/gtm-session-fetcher.git",
+      "state" : {
+        "revision" : "c0ac7575d70050c2973ba2318bd5af47f8e8153a",
+        "version" : "5.3.0"
+      }
+    },
+    {
+      "identity" : "interop-ios-for-google-sdks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/interop-ios-for-google-sdks.git",
+      "state" : {
+        "revision" : "040d087ac2267d2ddd4cca36c757d1c6a05fdbfe",
+        "version" : "101.0.0"
+      }
+    },
+    {
+      "identity" : "kakao-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kakao/kakao-ios-sdk",
+      "state" : {
+        "branch" : "master",
+        "revision" : "32626459f03d9a3622f91cfc001c6dc97cae33a9"
+      }
+    },
+    {
+      "identity" : "leveldb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/leveldb.git",
+      "state" : {
+        "revision" : "a0bc79961d7be727d258d33d5a6b2f1023270ba1",
+        "version" : "1.22.5"
+      }
+    },
+    {
+      "identity" : "nanopb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/nanopb.git",
+      "state" : {
+        "revision" : "b7e1104502eca3a213b46303391ca4d3bc8ddec1",
+        "version" : "2.30910.0"
+      }
+    },
+    {
+      "identity" : "promises",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/promises.git",
+      "state" : {
+        "revision" : "540318ecedd63d883069ae7f1ed811a2df00b6ac",
+        "version" : "2.4.0"
+      }
+    },
+    {
+      "identity" : "swift-package-manager-google-mobile-ads",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/googleads/swift-package-manager-google-mobile-ads.git",
+      "state" : {
+        "revision" : "a81f522aa4f59c0d90ee523d703bd426d5b27a03",
+        "version" : "13.4.0"
+      }
+    },
+    {
+      "identity" : "swift-package-manager-google-user-messaging-platform",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/googleads/swift-package-manager-google-user-messaging-platform.git",
+      "state" : {
+        "revision" : "13b248eaa73b7826f0efb1bcf455e251d65ecb1b",
+        "version" : "3.1.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/SoloDeveloperTraining/SoloDeveloperTraining.xcodeproj/project.pbxproj
+++ b/SoloDeveloperTraining/SoloDeveloperTraining.xcodeproj/project.pbxproj
@@ -97,6 +97,7 @@
 				"App/Info-Dev.plist",
 				App/Info.plist,
 				firebase.json,
+				Production/Analytics/AppsFlyerDelegate.swift,
 				"Production/Error/PurchasingError+UserReadableError.swift",
 				"Production/Error/SkillError+UserReadableError.swift",
 				Production/Error/UserReadableError.swift,

--- a/SoloDeveloperTraining/SoloDeveloperTraining.xcodeproj/project.pbxproj
+++ b/SoloDeveloperTraining/SoloDeveloperTraining.xcodeproj/project.pbxproj
@@ -663,6 +663,8 @@
 				INFOPLIST_FILE = SoloDeveloperTraining/App/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "개발자 키우기";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.games";
+				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "이미지를 사진 앨범에 저장하기 위해 권한이 필요합니다.";
+				INFOPLIST_KEY_NSUserTrackingUsageDescription = "개인화된 광고 제공 목적으로 사용됩니다.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = "Launch Screen";
@@ -711,6 +713,8 @@
 				INFOPLIST_FILE = SoloDeveloperTraining/App/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "개발자 키우기";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.games";
+				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "이미지를 사진 앨범에 저장하기 위해 권한이 필요합니다.";
+				INFOPLIST_KEY_NSUserTrackingUsageDescription = "개인화된 광고 제공 목적으로 사용됩니다.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = "Launch Screen";

--- a/SoloDeveloperTraining/SoloDeveloperTraining.xcodeproj/project.pbxproj
+++ b/SoloDeveloperTraining/SoloDeveloperTraining.xcodeproj/project.pbxproj
@@ -664,8 +664,6 @@
 				INFOPLIST_FILE = SoloDeveloperTraining/App/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "개발자 키우기";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.games";
-				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "이미지를 사진 앨범에 저장하기 위해 권한이 필요합니다.";
-				INFOPLIST_KEY_NSUserTrackingUsageDescription = "개인화된 광고 제공 목적으로 사용됩니다.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = "Launch Screen";
@@ -714,8 +712,6 @@
 				INFOPLIST_FILE = SoloDeveloperTraining/App/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "개발자 키우기";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.games";
-				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "이미지를 사진 앨범에 저장하기 위해 권한이 필요합니다.";
-				INFOPLIST_KEY_NSUserTrackingUsageDescription = "개인화된 광고 제공 목적으로 사용됩니다.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = "Launch Screen";

--- a/SoloDeveloperTraining/SoloDeveloperTraining.xcodeproj/project.pbxproj
+++ b/SoloDeveloperTraining/SoloDeveloperTraining.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		28FB12B22F9B5EB1004FCBB3 /* FirebaseFirestore in Frameworks */ = {isa = PBXBuildFile; productRef = 28FB12B12F9B5EB1004FCBB3 /* FirebaseFirestore */; };
 		BC19336F2F8FC7110033A27E /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = BC19336E2F8FC7110033A27E /* FirebaseAnalytics */; };
 		BC1933712F8FC7110033A27E /* FirebaseCore in Frameworks */ = {isa = PBXBuildFile; productRef = BC1933702F8FC7110033A27E /* FirebaseCore */; };
+		BC4C62982FE18C3C00570653 /* AppsFlyerLib in Frameworks */ = {isa = PBXBuildFile; productRef = BC4C62972FE18C3C00570653 /* AppsFlyerLib */; };
 		BCC0EACE2F8FE90700D7A84A /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = BCC0EACD2F8FE90700D7A84A /* FirebaseAnalytics */; };
 		BCC0EAD02F8FE90D00D7A84A /* FirebaseCore in Frameworks */ = {isa = PBXBuildFile; productRef = BCC0EACF2F8FE90D00D7A84A /* FirebaseCore */; };
 /* End PBXBuildFile section */
@@ -169,6 +170,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				283B980E2FAB24750033B924 /* GoogleMobileAds in Frameworks */,
+				BC4C62982FE18C3C00570653 /* AppsFlyerLib in Frameworks */,
 				BC1933712F8FC7110033A27E /* FirebaseCore in Frameworks */,
 				28AC32C92FDEB29600D0126E /* DUDesignSystem in Frameworks */,
 				BC19336F2F8FC7110033A27E /* FirebaseAnalytics in Frameworks */,
@@ -277,6 +279,7 @@
 				28F3C7C42FB73B7B0077B77A /* KakaoSDKShare */,
 				28F3C7C62FB73B820077B77A /* KakaoSDK */,
 				28AC32C82FDEB29600D0126E /* DUDesignSystem */,
+				BC4C62972FE18C3C00570653 /* AppsFlyerLib */,
 			);
 			productName = SoloDeveloperTraining;
 			productReference = 08267F2B2F0D06BC005A0066 /* SoloDeveloperTraining.app */;
@@ -394,6 +397,7 @@
 				283B95DB2FA9D44B0033B924 /* XCRemoteSwiftPackageReference "swift-package-manager-google-mobile-ads" */,
 				28F3C5032FB37EA70077B77A /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */,
 				28AC32CC2FDEB4BD00D0126E /* XCLocalSwiftPackageReference "../DUDesignSystem" */,
+				BC4C62962FE18C3C00570653 /* XCRemoteSwiftPackageReference "AppsFlyerFramework" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 08267F2C2F0D06BC005A0066 /* Products */;
@@ -1043,6 +1047,14 @@
 				minimumVersion = 12.12.0;
 			};
 		};
+		BC4C62962FE18C3C00570653 /* XCRemoteSwiftPackageReference "AppsFlyerFramework" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/AppsFlyerSDK/AppsFlyerFramework";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 7.0.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -1107,6 +1119,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = BC19336D2F8FC7110033A27E /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
 			productName = FirebaseCore;
+		};
+		BC4C62972FE18C3C00570653 /* AppsFlyerLib */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BC4C62962FE18C3C00570653 /* XCRemoteSwiftPackageReference "AppsFlyerFramework" */;
+			productName = AppsFlyerLib;
 		};
 		BCC0EACD2F8FE90700D7A84A /* FirebaseAnalytics */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/SoloDeveloperTraining/SoloDeveloperTraining/App/Info.plist
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/App/Info.plist
@@ -2,8 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSPhotoLibraryAddUsageDescription</key>
-	<string>이미지를 사진 앨범에 저장하기 위해 권한이 필요합니다.</string>
+	<key>ADMOB_INTERSTITIAL_AD_UNIT_ID</key>
+	<string>$(ADMOB_INTERSTITIAL_AD_UNIT_ID)</string>
+	<key>APPSFLYER_DEV_KEY</key>
+	<string>$(APPSFLYER_DEV_KEY)</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -21,6 +23,8 @@
 			</array>
 		</dict>
 	</array>
+	<key>GADApplicationIdentifier</key>
+	<string>$(GAD_APPLICATION_IDENTIFIER)</string>
 	<key>KAKAO_APP_KEY</key>
 	<string>$(KAKAO_APP_KEY)</string>
 	<key>LSApplicationQueriesSchemes</key>
@@ -29,18 +33,6 @@
 		<string>kakaotalk</string>
 		<string>kakaolink</string>
 	</array>
-	<key>NSUserTrackingUsageDescription</key>
-	<string>개인화된 광고 제공 목적으로 사용됩니다.</string>
-	<key>UIAppFonts</key>
-	<array>
-		<string>PFStardust-Regular.ttf</string>
-		<string>PFStardust-Bold.ttf</string>
-		<string>PFStardust-ExtraBold.ttf</string>
-	</array>
-	<key>GADApplicationIdentifier</key>
-	<string>$(GAD_APPLICATION_IDENTIFIER)</string>
-	<key>ADMOB_INTERSTITIAL_AD_UNIT_ID</key>
-	<string>$(ADMOB_INTERSTITIAL_AD_UNIT_ID)</string>
 	<key>SKAdNetworkItems</key>
 	<array>
 		<dict>
@@ -243,6 +235,12 @@
 			<key>SKAdNetworkIdentifier</key>
 			<string>3qcr597p9d.skadnetwork</string>
 		</dict>
+	</array>
+	<key>UIAppFonts</key>
+	<array>
+		<string>PFStardust-Regular.ttf</string>
+		<string>PFStardust-Bold.ttf</string>
+		<string>PFStardust-ExtraBold.ttf</string>
 	</array>
 </dict>
 </plist>

--- a/SoloDeveloperTraining/SoloDeveloperTraining/App/Info.plist
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/App/Info.plist
@@ -27,6 +27,10 @@
 	<string>$(GAD_APPLICATION_IDENTIFIER)</string>
 	<key>KAKAO_APP_KEY</key>
 	<string>$(KAKAO_APP_KEY)</string>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>이미지를 사진 앨범에 저장하기 위해 권한이 필요합니다.</string>
+	<key>NSUserTrackingUsageDescription</key>
+	<string>개인화된 광고 제공 목적으로 사용됩니다.</string>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>kakaokompassauth</string>

--- a/SoloDeveloperTraining/SoloDeveloperTraining/App/SoloDeveloperTrainingApp.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/App/SoloDeveloperTrainingApp.swift
@@ -41,6 +41,8 @@ struct SoloDeveloperTrainingApp: App {
             devKey: Bundle.main.appsFlyerDevKey,
             appId: "6758282441"
         )
+        AppsFlyerLib.shared().delegate = AppsFlyerDelegate.shared
+        AppsFlyerLib.shared().start()
     }
 
     @State private var hasSeenIntro = false

--- a/SoloDeveloperTraining/SoloDeveloperTraining/App/SoloDeveloperTrainingApp.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/App/SoloDeveloperTrainingApp.swift
@@ -5,6 +5,7 @@
 //  Created by SeoJunYoung on 1/6/26.
 //
 
+import AppsFlyerLib
 import SwiftUI
 import FirebaseCore
 import GoogleMobileAds
@@ -28,12 +29,18 @@ private enum Constant {
 @main
 struct SoloDeveloperTrainingApp: App {
 
-    // Firebase 초기화
     init() {
         FirebaseApp.configure()
+
         MobileAds.shared.start()
+
         let kakaoAppKey = Bundle.main.kakaoAppKey
         KakaoSDK.initSDK(appKey: kakaoAppKey)
+
+        AppsFlyerLib.shared().initialize(
+            devKey: Bundle.main.appsFlyerDevKey,
+            appId: "6758282441"
+        )
     }
 
     @State private var hasSeenIntro = false

--- a/SoloDeveloperTraining/SoloDeveloperTraining/App/SoloDeveloperTrainingApp.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/App/SoloDeveloperTrainingApp.swift
@@ -5,7 +5,9 @@
 //  Created by SeoJunYoung on 1/6/26.
 //
 
+#if canImport(AppsFlyerLib)
 import AppsFlyerLib
+#endif
 import SwiftUI
 import FirebaseCore
 import GoogleMobileAds
@@ -37,12 +39,14 @@ struct SoloDeveloperTrainingApp: App {
         let kakaoAppKey = Bundle.main.kakaoAppKey
         KakaoSDK.initSDK(appKey: kakaoAppKey)
 
+#if canImport(AppsFlyerLib)
         AppsFlyerLib.shared().initialize(
             devKey: Bundle.main.appsFlyerDevKey,
             appId: "6758282441"
         )
         AppsFlyerLib.shared().delegate = AppsFlyerDelegate.shared
         AppsFlyerLib.shared().start()
+#endif
     }
 
     @State private var hasSeenIntro = false

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Devlopment/Presentation/ScenarioTestView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Devlopment/Presentation/ScenarioTestView.swift
@@ -251,7 +251,12 @@ struct ScenarioTestView: View {
             ShareSheetView(
                 isPresented: $isShareSheetPresented,
                 kakaoMessageTemplateID: viewModel.kakaoMessageTemplateID,
-                urlString: "\(ShareService.baseURL)/\(viewModel.finalEnding?.type.webURLSlug ?? "")?share_id=\(currentShareID)&device_id=\(AnalyticsProperty.deviceIDValue)&result_id=\(viewModel.finalEnding?.id ?? "")"
+                shareID: currentShareID,
+                resultID: viewModel.finalEnding?.id ?? "",
+                urlString: "\(ShareService.baseURL)/\(viewModel.finalEnding?.type.webURLSlug ?? "")"
+                    + "?share_id=\(currentShareID)"
+                    + "&device_id=\(AnalyticsProperty.deviceIDValue)"
+                    + "&result_id=\(viewModel.finalEnding?.id ?? "")"
             )
         }
     }

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Devlopment/Presentation/ScenarioTestView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Devlopment/Presentation/ScenarioTestView.swift
@@ -241,6 +241,7 @@ final class ScenarioTestViewModel {
 struct ScenarioTestView: View {
     @State private var viewModel = ScenarioTestViewModel()
     @State private var isShareSheetPresented = false
+    @State private var currentShareID = UUID().uuidString
 
     var shareSheetOverlay: some View {
         ZStack {
@@ -250,7 +251,7 @@ struct ScenarioTestView: View {
             ShareSheetView(
                 isPresented: $isShareSheetPresented,
                 kakaoMessageTemplateID: viewModel.kakaoMessageTemplateID,
-                urlString: "\(ShareService.baseURL)/\(viewModel.finalEnding?.type.webURLSlug ?? "")"
+                urlString: "\(ShareService.baseURL)/\(viewModel.finalEnding?.type.webURLSlug ?? "")?share_id=\(currentShareID)&device_id=\(AnalyticsProperty.deviceIDValue)&result_id=\(viewModel.finalEnding?.id ?? "")"
             )
         }
     }
@@ -460,6 +461,7 @@ struct ScenarioTestView: View {
                         if viewModel.isFinalChoiceComplete {
                             VStack(spacing: 8) {
                                 Button {
+                                    currentShareID = UUID().uuidString
                                     isShareSheetPresented = true
                                 } label: {
                                     HStack {

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Extensions/Bundle+.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Extensions/Bundle+.swift
@@ -8,4 +8,8 @@ extension Bundle {
     var adMobInterstitialAdUnitID: String {
         return infoDictionary?["ADMOB_INTERSTITIAL_AD_UNIT_ID"] as? String ?? ""
     }
+
+    var appsFlyerDevKey: String {
+        infoDictionary?["APPSFLYER_DEV_KEY"] as? String ?? ""
+    }
 }

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AppsFlyerDelegate.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AppsFlyerDelegate.swift
@@ -1,0 +1,37 @@
+//
+//  AppsFlyerDelegate.swift
+//  SoloDeveloperTraining
+//
+//  Created by 김성훈 on 6/16/26.
+//
+
+import AppsFlyerLib
+
+final class AppsFlyerDelegate: NSObject, AppsFlyerLibDelegate {
+    static let shared = AppsFlyerDelegate()
+    private override init() {}
+
+    func onConversionDataSuccess(_ conversionInfo: [AnyHashable: Any]) {
+        guard let status = conversionInfo["af_status"] as? String,
+              status == "Non-organic",
+              let isFTD = conversionInfo["is_first_launch"] as? Bool,
+              isFTD else { return }
+
+        let referrerShareID = conversionInfo["share_id"] as? String ?? ""
+        let referrerDeviceID = conversionInfo["device_id"] as? String ?? ""
+        let resultID = conversionInfo["result_id"] as? String ?? ""
+        let entrySource = conversionInfo["entry_source"] as? String ?? "unknown"
+
+        AnalyticsService.shared.logDeferredDeeplinkOpened(
+            entrySource: entrySource,
+            referrerShareID: referrerShareID,
+            referrerDeviceID: referrerDeviceID,
+            isDeferredDeeplink: true,
+            resultID: resultID
+        )
+    }
+
+    func onConversionDataFail(_ error: any Error) {
+        print("❌ AppsFlyer 전환 데이터 실패: \(error)")
+    }
+}

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Scenario/ScenarioStoryView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Scenario/ScenarioStoryView.swift
@@ -110,6 +110,8 @@ struct ScenarioStoryView: View {
                 ShareSheetView(
                     isPresented: $isShareSheetPresented,
                     kakaoMessageTemplateID: ending.type.kakaoMessageTemplateID,
+                    shareID: currentShareID,
+                    resultID: ending.id,
                     urlString: "\(ShareService.baseURL)/\(ending.type.webURLSlug)?share_id=\(currentShareID)&device_id=\(AnalyticsProperty.deviceIDValue)&result_id=\(ending.id)"
                 )
                 .padding(.horizontal, TokenSpacing.lg)

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Scenario/ScenarioStoryView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Scenario/ScenarioStoryView.swift
@@ -21,6 +21,7 @@ struct ScenarioStoryView: View {
 
     // 공유하기
     @State private var isShareSheetPresented = false
+    @State private var currentShareID = UUID().uuidString
     // 환생하기
     @State private var isRebirthConfirmPopupPresented = false
     // 저장하기
@@ -86,6 +87,7 @@ struct ScenarioStoryView: View {
                                 }
                             },
                             onShare: {
+                                currentShareID = UUID().uuidString
                                 isShareSheetPresented = true
                             },
                             onRebirth: {
@@ -108,7 +110,7 @@ struct ScenarioStoryView: View {
                 ShareSheetView(
                     isPresented: $isShareSheetPresented,
                     kakaoMessageTemplateID: ending.type.kakaoMessageTemplateID,
-                    urlString: "\(ShareService.baseURL)/\(ending.type.webURLSlug)"
+                    urlString: "\(ShareService.baseURL)/\(ending.type.webURLSlug)?share_id=\(currentShareID)&device_id=\(AnalyticsProperty.deviceIDValue)&result_id=\(ending.id)"
                 )
                 .padding(.horizontal, TokenSpacing.lg)
             }

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/ShareSheetView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/ShareSheetView.swift
@@ -13,6 +13,8 @@ struct ShareSheetView: View {
     @State private var isCopied = false
 
     let kakaoMessageTemplateID: String
+    let shareID: String
+    let resultID: String
     let urlString: String
 
     var body: some View {
@@ -33,10 +35,15 @@ struct ShareSheetView: View {
                     image: .shareKakao,
                     title: "카카오톡",
                     action: {
-                        ShareService
-                            .shareToKakao(
-                                messageTemplateID: kakaoMessageTemplateID
-                            )
+                        ShareService.shareToKakao(
+                            messageTemplateID: kakaoMessageTemplateID,
+                            templateArgs: [
+                                "share_id": shareID,
+                                "device_id": AnalyticsProperty.deviceIDValue,
+                                "result_id": resultID,
+                                "entry_source": "kakao"
+                            ]
+                        )
                     }
                 )
 
@@ -98,6 +105,8 @@ private extension ShareSheetView {
     ShareSheetView(
         isPresented: $bindingIsPresented,
         kakaoMessageTemplateID: "",
+        shareID: "",
+        resultID: "",
         urlString: ""
     )
 }

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/ShareSheetView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/ShareSheetView.swift
@@ -24,7 +24,7 @@ struct ShareSheetView: View {
                     image: .shareLink,
                     title: "링크 복사",
                     action: {
-                        ShareService.copyLink(urlString)
+                        ShareService.copyLink(urlString + "&entry_source=link_copy")
                         isCopied = true
                     }
                 )
@@ -44,7 +44,7 @@ struct ShareSheetView: View {
                     image: .shareEtc,
                     title: "기타 공유",
                     action: {
-                        ShareService.defaultLinkShare(urlString)
+                        ShareService.defaultLinkShare(urlString + "&entry_source=other")
                     }
                 )
             }

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Share/ShareService.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Share/ShareService.swift
@@ -38,14 +38,14 @@ enum ShareService {
         topVC.present(activityVC, animated: true)
     }
 
-    static func shareToKakao(messageTemplateID: String) {
+    static func shareToKakao(messageTemplateID: String, templateArgs: [String: String]) {
         guard let templateID = Int64(messageTemplateID) else {
             print("❌ 잘못된 카카오 템플릿 ID: \(messageTemplateID)")
             return
         }
 
         if ShareApi.isKakaoTalkSharingAvailable() {
-            ShareApi.shared.shareCustom(templateId: templateID) { (sharingResult, error) in
+            ShareApi.shared.shareCustom(templateId: templateID, templateArgs: templateArgs) { (sharingResult, error) in
                 if let error = error {
                     print("❌ 카카오 공유 실패: \(error)")
                 } else if let sharingResult = sharingResult {
@@ -53,8 +53,7 @@ enum ShareService {
                 }
             }
         } else {
-            // 카카오톡 미설치 시 웹 브라우저 공유
-            if let url = ShareApi.shared.makeCustomUrl(templateId: templateID) {
+            if let url = ShareApi.shared.makeCustomUrl(templateId: templateID, templateArgs: templateArgs) {
                 UIApplication.shared.open(url)
             }
         }


### PR DESCRIPTION
## 연관된 이슈

- [KAN-119](https://devvup.atlassian.net/browse/KAN-119)

## 작업 내용 및 고민 내용

### URL 파라미터 추가
공유 시 수신자가 앱을 설치했을 때 어떤 공유로부터 유입됐는지 추적하기 위해
공유 URL에 아래 파라미터를 추가했습니다.

| 파라미터 | 설명 |
|---|---|
| `share_id` | 공유 버튼을 누를 때마다 생성되는 UUID. 공유 단위 식별에 사용 |
| `device_id` | 공유한 사람의 기기 ID |
| `result_id` | 공유된 엔딩 ID |
| `entry_source` | 공유 채널 (`kakao` / `link_copy` / `other`) |

**링크 복사 / 기타 공유**
- `ShareSheetView`에서 URL 쿼리스트링에 파라미터를 직접 append

**카카오 공유**
- `ShareService.shareToKakao`가 `templateArgs: [String: String]`을 받도록 수정
- `ShareSheetView`에서 `templateArgs`로 파라미터 전달
- Kakao Developers 메시지 템플릿 7개(133203~133208, 133210)의 iOS 앱 스킴 파라미터에  
`${share_id}`, `${device_id}`, `${result_id}`, `${entry_source}` 플레이스홀더 설정

**ScenarioStoryView / ScenarioTestView**
- `@State private var currentShareID = UUID().uuidString` 추가
- 공유 버튼 탭 시 `currentShareID` 갱신 후 `ShareSheetView`에 `shareID`, `resultID` 전달

---

### AppsFlyer SDK 연동
앱 미설치 상태에서 공유 링크를 받은 사용자가 App Store를 통해 설치했을 때
`deferred_deeplink_opened` 이벤트를 발송합니다.

- SPM으로 AppsFlyer iOS SDK v7.0.0 추가 (운영 타깃만)
- `SoloDeveloperTrainingApp.init()`에서 SDK 초기화 및 `start()` 호출
- `AppsFlyerDelegate`(`AppsFlyerLibDelegate`)에서 `onConversionDataSuccess` 콜백으로 디퍼드 딥링크 파라미터 복원
- `af_status == "Non-organic"` + `is_first_launch == true` 조건에서만 `AnalyticsService.logDeferredDeeplinkOpened` 호출
  - `af_status == "Non-organic"`: 유기적 설치(그냥 App Store 검색)가 아닌, 공유 링크 유입 설치
  - `is_first_launch == true`: 앱을 처음 실행하는 경우 (재설치가 아닌 신규 설치)
- Dev Key는 xcconfig(`APPSFLYER_DEV_KEY`)로 관리, Info.plist에서 `$(APPSFLYER_DEV_KEY)`로 참조

---

### 참고 사항
- xcconfig에 `APPSFLYER_DEV_KEY = $(키값은 디스코드로 공유드리겠습니다.)` 추가 필요
- AppsFlyer 계정 가입 및 앱 등록 완료 (App ID: 6758282441)
- AppsFlyer 대시보드에서 in-app events 설정 완료
- Kakao Developers 메시지 템플릿 7개 파라미터 설정 완료