### PR TITLE
'공유하기' 관련 이벤트를 적용합니다.

### DIFF
--- a/SoloDeveloperTraining/SoloDeveloperTraining/App/SoloDeveloperTrainingApp.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/App/SoloDeveloperTrainingApp.swift
@@ -98,7 +98,15 @@ private extension SoloDeveloperTrainingApp {
         }
         .animation(.easeOut(duration: Constant.Animation.transitionDuration), value: hasSeenIntro)
         .onOpenURL { url in
-            print("\(url) app open")
+            guard let deeplinkInfo = parseOpenURL(url) else { return }
+
+            AnalyticsService.shared
+                .logAppOpenedFromDeeplink(
+                    entrySource: deeplinkInfo.entrySource,
+                    referrerShareID: deeplinkInfo.referrerShareID,
+                    isDeferredDeeplink: false,
+                    resultID: deeplinkInfo.resultID
+                )
         }
         .overlay {
             nicknameSetupOverlay
@@ -276,4 +284,39 @@ private extension SoloDeveloperTrainingApp {
         AnalyticsKeychain.getOrCreateDeviceID()
         AnalyticsService.shared.logFirstOpen(level: user.career.level)
     }
+
+    struct DeeplinkInfo {
+        let entrySource: String
+        let referrerShareID: String
+        let resultID: String
+    }
+
+    func parseOpenURL(_ url: URL) -> DeeplinkInfo? {
+        guard let components = URLComponents(
+            url: url,
+            resolvingAgainstBaseURL: false
+        ) else {
+            return nil
+        }
+
+        let queryItems = components.queryItems ?? []
+
+        guard
+            let shareID = queryItems.first(where: { $0.name == "share_id" })?.value,
+            let resultID = queryItems.first(where: { $0.name == "result_id" })?.value
+        else {
+            return nil
+        }
+
+        let entrySource = queryItems
+            .first(where: { $0.name == "entry_source" })?
+            .value ?? "unknown"
+
+        return DeeplinkInfo(
+            entrySource: entrySource,
+            referrerShareID: shareID,
+            resultID: resultID
+        )
+    }
+
 }

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AnalyticsService.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AnalyticsService.swift
@@ -10,6 +10,10 @@ import FirebaseAnalytics
 private typealias AP = AnalyticsProperty
 
 final class AnalyticsService {
+    enum ShareChannel: String  {
+        case link, kakao, os, unknown
+    }
+
     static let shared = AnalyticsService()
 
     /// 광고 이벤트별 flow ID 중복 로깅 방지
@@ -70,14 +74,14 @@ final class AnalyticsService {
     func logShareButtonClicked(
         shareID: String,
         resultID: String,
-        shareChannel: String
+        shareChannel: ShareChannel
     ) {
         Analytics.logEvent("share_button_clicked", parameters: [
             AP.deviceID: AP.deviceIDValue,
             AP.sessionID: SessionManager.shared.sessionID,
             AP.shareID: shareID,
             AP.resultID: resultID,
-            AP.shareChannel: shareChannel
+            AP.shareChannel: shareChannel.rawValue
         ])
     }
 

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AnalyticsService.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AnalyticsService.swift
@@ -16,6 +16,10 @@ final class AnalyticsService {
     /// 광고 이벤트별 flow ID 중복 로깅 방지
     private var loggedAdRewardFlowIDsByEvent: [AdAnalyticsEvent: Set<String>] = [:]
 
+    /// 공유하기 중복 로깅 방지
+    private var loggedShareCompletions: Set<String> = []
+    private var loggedAppOpenedFromDeeplinkSessions: Set<String> = []
+
     private init() {}
 
     // MARK: - 성장
@@ -90,6 +94,9 @@ final class AnalyticsService {
         referrerShareID: String,
         referrerDeviceID: String
     ) {
+        let key = "\(shareID)_\(shareChannel)"
+        guard loggedShareCompletions.insert(key).inserted else { return }
+
         Analytics.logEvent("share_completed", parameters: [
             AP.deviceID: AP.deviceIDValue,
             AP.sessionID: SessionManager.shared.sessionID,
@@ -108,6 +115,9 @@ final class AnalyticsService {
         isDeferredDeeplink: Bool,
         resultID: String
     ) {
+        let sessionID = SessionManager.shared.sessionID
+        guard loggedAppOpenedFromDeeplinkSessions.insert(sessionID).inserted else { return }
+
         Analytics.logEvent("app_opened_from_deeplink", parameters: [
             AP.deviceID: AP.deviceIDValue,
             AP.sessionID: SessionManager.shared.sessionID,

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AnalyticsService.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AnalyticsService.swift
@@ -88,7 +88,7 @@ final class AnalyticsService {
     /// 공유 완료 감지
     func logShareCompleted(
         shareID: String,
-        shareChannel: String,
+        shareChannel: ShareChannel,
         resultID: String,
         referrerShareID: String,
         referrerDeviceID: String
@@ -97,7 +97,7 @@ final class AnalyticsService {
             AP.deviceID: AP.deviceIDValue,
             AP.sessionID: SessionManager.shared.sessionID,
             AP.shareID: shareID,
-            AP.shareChannel: shareChannel,
+            AP.shareChannel: shareChannel.rawValue,
             AP.resultID: resultID,
             AP.referrerShareID: referrerShareID,
             AP.referrerDeviceID: referrerDeviceID

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AnalyticsService.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AnalyticsService.swift
@@ -10,9 +10,6 @@ import FirebaseAnalytics
 private typealias AP = AnalyticsProperty
 
 final class AnalyticsService {
-    enum ShareChannel: String  {
-        case link, kakao, os, unknown
-    }
 
     static let shared = AnalyticsService()
 
@@ -74,21 +71,21 @@ final class AnalyticsService {
     func logShareButtonClicked(
         shareID: String,
         resultID: String,
-        shareChannel: ShareChannel
+        shareChannel: String
     ) {
         Analytics.logEvent("share_button_clicked", parameters: [
             AP.deviceID: AP.deviceIDValue,
             AP.sessionID: SessionManager.shared.sessionID,
             AP.shareID: shareID,
             AP.resultID: resultID,
-            AP.shareChannel: shareChannel.rawValue
+            AP.shareChannel: shareChannel
         ])
     }
 
     /// 공유 완료 감지
     func logShareCompleted(
         shareID: String,
-        shareChannel: ShareChannel,
+        shareChannel: String,
         resultID: String,
         referrerShareID: String,
         referrerDeviceID: String
@@ -97,7 +94,7 @@ final class AnalyticsService {
             AP.deviceID: AP.deviceIDValue,
             AP.sessionID: SessionManager.shared.sessionID,
             AP.shareID: shareID,
-            AP.shareChannel: shareChannel.rawValue,
+            AP.shareChannel: shareChannel,
             AP.resultID: resultID,
             AP.referrerShareID: referrerShareID,
             AP.referrerDeviceID: referrerDeviceID

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Scenario/ScenarioStoryView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Scenario/ScenarioStoryView.swift
@@ -75,8 +75,7 @@ struct ScenarioStoryView: View {
                 Group {
                     if let ending = finalEnding {
                         // 3. 엔딩 전용 버튼 (저장/공유/환생)
-                        EventButton(
-type: .ending(
+                        EventButton(type: .ending(
                             onSave: {
                                 guard let image = renderEndingImage(ending) else {
                                     return

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Scenario/ScenarioStoryView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Scenario/ScenarioStoryView.swift
@@ -73,12 +73,12 @@ struct ScenarioStoryView: View {
                 }
 
                 Group {
-                    if finalEnding != nil {
+                    if let ending = finalEnding {
                         // 3. 엔딩 전용 버튼 (저장/공유/환생)
-                        EventButton(type: .ending(
+                        EventButton(
+type: .ending(
                             onSave: {
-                                guard let ending = finalEnding,
-                                      let image = renderEndingImage(ending) else {
+                                guard let image = renderEndingImage(ending) else {
                                     return
                                 }
                                 PhotoLibraryService.saveImageToPhotoLibrary(image) { success in
@@ -87,13 +87,21 @@ struct ScenarioStoryView: View {
                                 }
                             },
                             onShare: {
+                                AnalyticsService.shared
+                                    .logShareButtonClicked(
+                                        shareID: currentShareID,
+                                        resultID: ending.id,
+                                        shareChannel: .unknown
+                                    )
+
                                 currentShareID = UUID().uuidString
                                 isShareSheetPresented = true
                             },
                             onRebirth: {
                                 isRebirthConfirmPopupPresented = true
                             }
-                        ))
+                        )
+)
                     } else if let page = manager.currentPage {
                         // 4. 일반 진행 버튼 (다음/선택/다시선택)
                         eventButtonView(for: page)

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Scenario/ScenarioStoryView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Scenario/ScenarioStoryView.swift
@@ -92,7 +92,7 @@ type: .ending(
                                     .logShareButtonClicked(
                                         shareID: currentShareID,
                                         resultID: ending.id,
-                                        shareChannel: .unknown
+                                        shareChannel: ShareChannel.unknown.rawValue
                                     )
                                 isShareSheetPresented = true
                             },

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Scenario/ScenarioStoryView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Scenario/ScenarioStoryView.swift
@@ -21,7 +21,7 @@ struct ScenarioStoryView: View {
 
     // 공유하기
     @State private var isShareSheetPresented = false
-    @State private var currentShareID = UUID().uuidString
+    @State private var currentShareID = ""
     // 환생하기
     @State private var isRebirthConfirmPopupPresented = false
     // 저장하기
@@ -87,14 +87,13 @@ type: .ending(
                                 }
                             },
                             onShare: {
+                                currentShareID = UUID().uuidString
                                 AnalyticsService.shared
                                     .logShareButtonClicked(
                                         shareID: currentShareID,
                                         resultID: ending.id,
                                         shareChannel: .unknown
                                     )
-
-                                currentShareID = UUID().uuidString
                                 isShareSheetPresented = true
                             },
                             onRebirth: {

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/ShareSheetView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/ShareSheetView.swift
@@ -8,6 +8,13 @@
 import SwiftUI
 import DUDesignSystem
 
+enum ShareChannel: String {
+    case copyLink = "copy_link"
+    case kakao = "kakao"
+    case osShare = "os_share"
+    case unknown = "unknown"
+}
+
 struct ShareSheetView: View {
     @Binding var isPresented: Bool
     @State private var isCopied = false
@@ -28,12 +35,12 @@ struct ShareSheetView: View {
                     action: {
                         ShareService
                             .copyLink(
-                                urlString + "&entry_source=link_copy",
+                                urlString + "&entry_source=\(ShareChannel.copyLink.rawValue)",
                                 onCompleted: {
                                     AnalyticsService.shared
                                         .logShareCompleted(
                                             shareID: shareID,
-                                            shareChannel: .link,
+                                            shareChannel: ShareChannel.copyLink.rawValue,
                                             resultID: resultID,
                                             referrerShareID: shareID,
                                             referrerDeviceID: AnalyticsProperty.deviceID)
@@ -53,13 +60,13 @@ struct ShareSheetView: View {
                                 "share_id": shareID,
                                 "device_id": AnalyticsProperty.deviceIDValue,
                                 "result_id": resultID,
-                                "entry_source": "kakao"
+                                "entry_source": ShareChannel.kakao.rawValue
                             ],
                             onCompleted: {
                                 AnalyticsService.shared
                                     .logShareCompleted(
                                         shareID: shareID,
-                                        shareChannel: .kakao,
+                                        shareChannel: ShareChannel.kakao.rawValue,
                                         resultID: resultID,
                                         referrerShareID: shareID,
                                         referrerDeviceID: AnalyticsProperty.deviceID)
@@ -74,12 +81,12 @@ struct ShareSheetView: View {
                     action: {
                         ShareService
                             .defaultLinkShare(
-                                urlString + "&entry_source=other",
+                                urlString + "&entry_source=\(ShareChannel.osShare.rawValue)",
                                 onCompleted: {
                                     AnalyticsService.shared
                                         .logShareCompleted(
                                             shareID: shareID,
-                                            shareChannel: .os,
+                                            shareChannel: ShareChannel.osShare.rawValue,
                                             resultID: resultID,
                                             referrerShareID: shareID,
                                             referrerDeviceID: AnalyticsProperty.deviceID)

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/ShareSheetView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/ShareSheetView.swift
@@ -26,7 +26,19 @@ struct ShareSheetView: View {
                     image: .shareLink,
                     title: "링크 복사",
                     action: {
-                        ShareService.copyLink(urlString + "&entry_source=link_copy")
+                        ShareService
+                            .copyLink(
+                                urlString + "&entry_source=link_copy",
+                                onCompleted: {
+                                    AnalyticsService.shared
+                                        .logShareCompleted(
+                                            shareID: shareID,
+                                            shareChannel: .link,
+                                            resultID: resultID,
+                                            referrerShareID: shareID,
+                                            referrerDeviceID: AnalyticsProperty.deviceID)
+                                }
+                            )
                         isCopied = true
                     }
                 )
@@ -42,7 +54,16 @@ struct ShareSheetView: View {
                                 "device_id": AnalyticsProperty.deviceIDValue,
                                 "result_id": resultID,
                                 "entry_source": "kakao"
-                            ]
+                            ],
+                            onCompleted: {
+                                AnalyticsService.shared
+                                    .logShareCompleted(
+                                        shareID: shareID,
+                                        shareChannel: .kakao,
+                                        resultID: resultID,
+                                        referrerShareID: shareID,
+                                        referrerDeviceID: AnalyticsProperty.deviceID)
+                            }
                         )
                     }
                 )
@@ -51,7 +72,19 @@ struct ShareSheetView: View {
                     image: .shareEtc,
                     title: "기타 공유",
                     action: {
-                        ShareService.defaultLinkShare(urlString + "&entry_source=other")
+                        ShareService
+                            .defaultLinkShare(
+                                urlString + "&entry_source=other",
+                                onCompleted: {
+                                    AnalyticsService.shared
+                                        .logShareCompleted(
+                                            shareID: shareID,
+                                            shareChannel: .os,
+                                            resultID: resultID,
+                                            referrerShareID: shareID,
+                                            referrerDeviceID: AnalyticsProperty.deviceID)
+                                }
+                            )
                     }
                 )
             }

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Share/ShareService.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Share/ShareService.swift
@@ -13,11 +13,12 @@ import KakaoSDKCommon
 enum ShareService {
     static let baseURL = "https://solodevelopertraining.web.app"
 
-    static func copyLink(_ urlString: String) {
+    static func copyLink(_ urlString: String, onCompleted: () -> Void) {
         UIPasteboard.general.string = urlString
+        onCompleted()
     }
 
-    static func defaultLinkShare(_ urlString: String) {
+    static func defaultLinkShare(_ urlString: String, onCompleted: @escaping () -> Void) {
         guard let shareURL = URL(string: urlString) else { return }
 
         let activityVC = UIActivityViewController(
@@ -25,11 +26,20 @@ enum ShareService {
             applicationActivities: nil
         )
 
+        activityVC.completionWithItemsHandler = { _, completed, _, error in
+              if let error {
+                  print("❌ 기본 시트 공유 실패: \(error)")
+                  return
+              }
+
+              guard completed else { return }
+              onCompleted()
+          }
+
         guard let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
               let rootVC = scene.windows.first(where: { $0.isKeyWindow })?.rootViewController
-        else {
-            return
-        }
+        else { return }
+
         var topVC = rootVC
         while let presented = topVC.presentedViewController {
             topVC = presented
@@ -38,7 +48,7 @@ enum ShareService {
         topVC.present(activityVC, animated: true)
     }
 
-    static func shareToKakao(messageTemplateID: String, templateArgs: [String: String]) {
+    static func shareToKakao(messageTemplateID: String, templateArgs: [String: String], onCompleted: @escaping () -> Void) {
         guard let templateID = Int64(messageTemplateID) else {
             print("❌ 잘못된 카카오 템플릿 ID: \(messageTemplateID)")
             return
@@ -50,12 +60,15 @@ enum ShareService {
                     print("❌ 카카오 공유 실패: \(error)")
                 } else if let sharingResult = sharingResult {
                     UIApplication.shared.open(sharingResult.url)
+                    onCompleted()
                 }
             }
         } else {
             if let url = ShareApi.shared.makeCustomUrl(templateId: templateID, templateArgs: templateArgs) {
                 UIApplication.shared.open(url)
+                onCompleted()
             }
         }
     }
+
 }


### PR DESCRIPTION
## 연관된 이슈

- [KAN-73](https://devvup.atlassian.net/browse/KAN-73)

## 작업 내용 및 고민 내용

### share_button_clicked 이벤트 적용
- 발생 트리거: 엔딩 화면에서 '공유하기' 버튼 누를 경우 발생
- 중복 처리 기준: 따로 없음
- 특이사항: share_channel = .unknown 상태

### share_completed 이벤트 적용
- 발생 트리거: 3개의 공유 경로에서 각각 아래 시점에 발생
  - 링크 복사: 링크가 복사되었을 때 
  - 카카오톡: 카카오톡 공유하기를 클릭하고 앱이 열렸을 때
  - 기타 공유: UIViewActivityController의 completionHandler 사용 (시트 내에서 사용자가 컨텐츠를 클릭하면 true, 시트를 내리거나 취소하면 false 반환)
- 중복 처리 기준: `share_id + share_channel` 당 1회, AnalyticsService 내에 `Set<String>` 타입 변수로 관리
- 특이사항: share_channel 값을 반복적으로 하드코딩 하지 않기 위해 각 공유 채널 케이스를 나타내는 `ShareChannel` enum 타입 선언 > `case kakao, osShare, copyLink, unknown`

### app_opened_from_deeplink 이벤트 적용
- 발생 트리거: App file의 `.onOpenURL` 클로저에서 '딥링크 파라미터' 파싱에 성공했을 경우
- 중복 처리 기준: 앱 `session_id` 기준 1회, `AnalyticsService` 내에 `Set<String>` 타입 변수로 관리
- 특이사항: onOpenURL 클로저 실행 시 링크 파싱 로직 추가, 파싱 성공 시에만 이벤트 전송

## 스크린샷
<img width="724" height="396" alt="image" src="https://github.com/user-attachments/assets/37f2a706-a62f-4c95-bc4b-4eeae9f560e0" />



