### PR TITLE
광고 보상 흐름에 Google Analytics 이벤트 5종을 연결합니다.

### DIFF
--- a/SoloDeveloperTraining/SoloDeveloperTraining/App/Info.plist
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/App/Info.plist
@@ -30,7 +30,7 @@
 	<key>NSPhotoLibraryAddUsageDescription</key>
 	<string>이미지를 저장하기 위해 권한이 필요합니다.</string>
 	<key>NSUserTrackingUsageDescription</key>
-	<string>개인화된 광고 제공 목적으로 사용됩니다.</string>
+	<string>맞춤형 광고 제공 및 광고 성과 측정을 위해 사용됩니다.</string>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>kakaokompassauth</string>

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Devlopment/Presentation/AdView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Devlopment/Presentation/AdView.swift
@@ -13,10 +13,10 @@ struct AdView: View {
             Section(header: Text("광고 테스트")) {
                 Button("전면 광고 노출") {
                     Task {
-                        let success = await AdService.shared.showAdWithResult(
+                        let result = await AdService.shared.showAdWithResult(
                             .interstitial
                         )
-                        if success {
+                        if result.success {
                             print("광고가 닫히면 실행됩니다.")
                         }
                     }

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Advertisement/AdService.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Advertisement/AdService.swift
@@ -11,6 +11,11 @@ enum AdType: String {
     case interstitial
 }
 
+struct AdShowResult {
+    let success: Bool
+    let watchDurationSec: Int
+}
+
 @MainActor
 final class AdService {
     static let shared: AdService = {
@@ -31,9 +36,9 @@ final class AdService {
         await loadAdIfNeeded(type)
     }
 
-    // 광고 표시 후 결과 반환 (true: 정상 시청 완료, false: 실패)
-    func showAdWithResult(_ type: AdType) async -> Bool {
-        guard !isShowing else { return false }
+    // 광고 표시 후 결과 반환 (success: 정상 시청 완료 여부, watchDurationSec: 순수 시청 시간)
+    func showAdWithResult(_ type: AdType) async -> AdShowResult {
+        guard !isShowing else { return AdShowResult(success: false, watchDurationSec: 0) }
         isShowing = true
         defer { isShowing = false }
 
@@ -41,17 +46,20 @@ final class AdService {
 
         guard let ads = await loadAdIfNeeded(type) else {
             print("⚠️ Ad not ready")
-            return false
+            return AdShowResult(success: false, watchDurationSec: 0)
         }
 
         loadedAds.removeValue(forKey: type)
+
+        let startedAt = Date()
         let result = await ads.showWithResult()
+        let watchDurationSec = Int(Date().timeIntervalSince(startedAt).rounded())
 
         Task {
             await loadAd(type)
         }
 
-        return result
+        return AdShowResult(success: result, watchDurationSec: watchDurationSec)
     }
 }
 

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AdAnalyticsSchema.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AdAnalyticsSchema.swift
@@ -29,6 +29,8 @@ enum AdRewardType: String {
     case coffee
     case energyDrink
     case reselect
+    case skillBoost
+    case enhanceRateBoost
 }
 
 enum AdOfferDismissReasonType: String {

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AdAnalyticsSchema.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AdAnalyticsSchema.swift
@@ -35,6 +35,5 @@ enum AdRewardType: String {
 
 enum AdOfferDismissReasonType: String {
     case close
-    case background
     case unknown
 }

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/MainView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/MainView.swift
@@ -38,6 +38,7 @@ struct MainView: View {
     @State private var showRewardToast: Bool = false
     @State private var rewardToastMessage: String = ""
     @State private var selectedDrinkType: ConsumableType?
+    @State private var drinkAdRewardFlowID: String?
 
     // 스킬 광고 보상 지속시 남은 시간
     @State private var skillAdRewardNow = Date()
@@ -461,6 +462,7 @@ private extension MainView {
                     text: "대신에 광고를 보고\n카페인을 보충할까요?"
                 )
             }
+            .onAppear { trackDrinkAdOfferIfNeeded(drinkType: drinkType) }
         }
     }
 
@@ -511,21 +513,56 @@ private extension MainView {
         .ignoresSafeArea()
     }
 
+    func trackDrinkAdOfferIfNeeded(drinkType: ConsumableType) {
+        guard drinkAdRewardFlowID == nil else { return }
+
+        let flowID = AnalyticsService.shared.makeAdRewardFlowID()
+        drinkAdRewardFlowID = flowID
+        AnalyticsService.shared.logAdOfferViewed(
+            adRewardFlowID: flowID,
+            adPlacement: .consumable,
+            rewardType: drinkType == .coffee ? .coffee : .energyDrink,
+            rewardAmount: 1
+        )
+    }
+
     func handleWatchAdInMainView() async {
         showDrinkAdPopup = false
 
-        guard let drinkType = selectedDrinkType else { return }
+        guard let drinkType = selectedDrinkType, let flowID = drinkAdRewardFlowID else { return }
+        let rewardType: AdRewardType = drinkType == .coffee ? .coffee : .energyDrink
+
+        AnalyticsService.shared.logAdWatchClicked(
+            adRewardFlowID: flowID,
+            adPlacement: .consumable,
+            rewardType: rewardType,
+            rewardAmount: 1
+        )
 
         // 광고 시청
         let result = await AdService.shared.showAdWithResult(.interstitial)
+        drinkAdRewardFlowID = nil
 
         if result.success {
+            AnalyticsService.shared.logAdWatchCompleted(
+                adRewardFlowID: flowID,
+                adPlacement: .consumable,
+                rewardType: rewardType,
+                rewardAmount: 1,
+                adWatchDurationSec: result.watchDurationSec
+            )
             // 보상 지급
             user.inventory.gain(consumable: drinkType)
             rewardToastMessage = "카페인 충전 완료!"
             showRewardToast = true
             selectedDrinkType = nil
             workGameSession.resumeGame?()
+            AnalyticsService.shared.logAdRewardClaimed(
+                adRewardFlowID: flowID,
+                adPlacement: .consumable,
+                rewardType: rewardType,
+                rewardAmount: 1
+            )
         } else {
             // 광고 실패 시 초기화
             selectedDrinkType = nil
@@ -534,6 +571,16 @@ private extension MainView {
 
     func handleSkipAdInMainView() {
         showDrinkAdPopup = false
+        if let flowID = drinkAdRewardFlowID, let drinkType = selectedDrinkType {
+            AnalyticsService.shared.logAdOfferDismissed(
+                adRewardFlowID: flowID,
+                adPlacement: .consumable,
+                rewardType: drinkType == .coffee ? .coffee : .energyDrink,
+                rewardAmount: 1,
+                dismissReason: .close
+            )
+            drinkAdRewardFlowID = nil
+        }
         selectedDrinkType = nil
         workGameSession.resumeGame?()
     }

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/MainView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/MainView.swift
@@ -53,6 +53,9 @@ struct MainView: View {
     @State private var showOfflineRewardToast: Bool = false
     @State private var offlineRewardToastMessage: String = ""
     @State private var hasCheckedOfflineReward: Bool = false
+    @State private var offlineRewardAdFlowID: String?
+
+    // 팝업 Anchor 관련
     @State private var tabbarAnchorY: CGFloat = 0
     @State private var bottomAnchorY: CGFloat = 0
 
@@ -695,6 +698,7 @@ private extension MainView {
                     text: "잠자는 시간 동안 '\(user.nickname)'가 일을 했습니다.\n일한 보상을 받을까요?"
                 )
             }
+            .onAppear { trackOfflineRewardAdOfferIfNeeded() }
         }
     }
 
@@ -719,15 +723,51 @@ private extension MainView {
         }
     }
 
+    func trackOfflineRewardAdOfferIfNeeded() {
+        guard offlineRewardAdFlowID == nil else { return }
+
+        let flowID = AnalyticsService.shared.makeAdRewardFlowID()
+        offlineRewardAdFlowID = flowID
+        AnalyticsService.shared.logAdOfferViewed(
+            adRewardFlowID: flowID,
+            adPlacement: .offlineReward,
+            rewardType: .gold,
+            rewardAmount: offlineRewardGold
+        )
+    }
+
     func handleOfflineRewardWatchAd() async {
         showOfflineRewardPopup = false
+        guard let flowID = offlineRewardAdFlowID else { return }
+        let rewardGold = offlineRewardGold
+
+        AnalyticsService.shared.logAdWatchClicked(
+            adRewardFlowID: flowID,
+            adPlacement: .offlineReward,
+            rewardType: .gold,
+            rewardAmount: rewardGold
+        )
 
         let result = await AdService.shared.showAdWithResult(.interstitial)
+        offlineRewardAdFlowID = nil
 
         if result.success {
+            AnalyticsService.shared.logAdWatchCompleted(
+                adRewardFlowID: flowID,
+                adPlacement: .offlineReward,
+                rewardType: .gold,
+                rewardAmount: rewardGold,
+                adWatchDurationSec: result.watchDurationSec
+            )
             user.wallet.addGold(offlineRewardGold)
             offlineRewardToastMessage = "잠자는 시간에 일한 보상 획득!"
             showOfflineRewardToast = true
+            AnalyticsService.shared.logAdRewardClaimed(
+                adRewardFlowID: flowID,
+                adPlacement: .offlineReward,
+                rewardType: .gold,
+                rewardAmount: rewardGold
+            )
         }
         offlineRewardGold = 0
         offlineRewardHours = 0.0
@@ -735,13 +775,22 @@ private extension MainView {
 
     func handleOfflineRewardSkip() {
         showOfflineRewardPopup = false
+        if let flowID = offlineRewardAdFlowID {
+            AnalyticsService.shared.logAdOfferDismissed(
+                adRewardFlowID: flowID,
+                adPlacement: .offlineReward,
+                rewardType: .gold,
+                rewardAmount: offlineRewardGold,
+                dismissReason: .close
+            )
+            offlineRewardAdFlowID = nil
+        }
         // 데이터 초기화
         offlineRewardGold = 0
         offlineRewardHours = 0.0
         // 다음 체크를 위해 플래그 리셋
         hasCheckedOfflineReward = false
     }
-
 }
 
 #Preview {

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/MainView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/MainView.swift
@@ -517,9 +517,9 @@ private extension MainView {
         guard let drinkType = selectedDrinkType else { return }
 
         // 광고 시청
-        let success = await AdService.shared.showAdWithResult(.interstitial)
+        let result = await AdService.shared.showAdWithResult(.interstitial)
 
-        if success {
+        if result.success {
             // 보상 지급
             user.inventory.gain(consumable: drinkType)
             rewardToastMessage = "카페인 충전 완료!"
@@ -540,8 +540,8 @@ private extension MainView {
 
     func handleExitBonusAd() async {
         workGameSession.showsExitBonusPopup = false
-        let success = await AdService.shared.showAdWithResult(.interstitial)
-        if success {
+        let result = await AdService.shared.showAdWithResult(.interstitial)
+        if result.success {
             applyExitBonus()
         }
         exitWorkGame()
@@ -620,9 +620,9 @@ private extension MainView {
     func handleOfflineRewardWatchAd() async {
         showOfflineRewardPopup = false
 
-        let success = await AdService.shared.showAdWithResult(.interstitial)
+        let result = await AdService.shared.showAdWithResult(.interstitial)
 
-        if success {
+        if result.success {
             user.wallet.addGold(offlineRewardGold)
             offlineRewardToastMessage = "잠자는 시간에 일한 보상 획득!"
             showOfflineRewardToast = true

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/MainView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/MainView.swift
@@ -40,6 +40,9 @@ struct MainView: View {
     @State private var selectedDrinkType: ConsumableType?
     @State private var drinkAdRewardFlowID: String?
 
+    // 업무 퇴장 보너스 광고 관련
+    @State private var exitBonusAdRewardFlowID: String?
+
     // 스킬 광고 보상 지속시 남은 시간
     @State private var skillAdRewardNow = Date()
 
@@ -481,6 +484,7 @@ private extension MainView {
                     text: "광고를 본다면 업무에서 얻은 재화만큼\n더 벌 수 있습니다"
                 )
             }
+            .onAppear { trackExitBonusAdOfferIfNeeded() }
         }
     }
 
@@ -585,16 +589,67 @@ private extension MainView {
         workGameSession.resumeGame?()
     }
 
+    func trackExitBonusAdOfferIfNeeded() {
+        guard exitBonusAdRewardFlowID == nil else { return }
+
+        let flowID = AnalyticsService.shared.makeAdRewardFlowID()
+        exitBonusAdRewardFlowID = flowID
+        AnalyticsService.shared.logAdOfferViewed(
+            adRewardFlowID: flowID,
+            adPlacement: .workExit,
+            rewardType: .gold,
+            rewardAmount: max(0, workGameSession.actionGoldDelta)
+        )
+    }
+
     func handleExitBonusAd() async {
         workGameSession.showsExitBonusPopup = false
+        guard let flowID = exitBonusAdRewardFlowID else {
+            exitWorkGame()
+            return
+        }
+        let bonusGold = max(0, workGameSession.actionGoldDelta)
+
+        AnalyticsService.shared.logAdWatchClicked(
+            adRewardFlowID: flowID,
+            adPlacement: .workExit,
+            rewardType: .gold,
+            rewardAmount: bonusGold
+        )
+
         let result = await AdService.shared.showAdWithResult(.interstitial)
+        exitBonusAdRewardFlowID = nil
+
         if result.success {
+            AnalyticsService.shared.logAdWatchCompleted(
+                adRewardFlowID: flowID,
+                adPlacement: .workExit,
+                rewardType: .gold,
+                rewardAmount: bonusGold,
+                adWatchDurationSec: result.watchDurationSec
+            )
             applyExitBonus()
+            AnalyticsService.shared.logAdRewardClaimed(
+                adRewardFlowID: flowID,
+                adPlacement: .workExit,
+                rewardType: .gold,
+                rewardAmount: bonusGold
+            )
         }
         exitWorkGame()
     }
 
     func handleExitWithoutBonus() {
+        if let flowID = exitBonusAdRewardFlowID {
+            AnalyticsService.shared.logAdOfferDismissed(
+                adRewardFlowID: flowID,
+                adPlacement: .workExit,
+                rewardType: .gold,
+                rewardAmount: max(0, workGameSession.actionGoldDelta),
+                dismissReason: .close
+            )
+            exitBonusAdRewardFlowID = nil
+        }
         if let pendingTab = workGameSession.closeExitBonusPopupAndReturnPendingTab() {
             selectedTab = pendingTab
         }

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Scenario/ScenarioStoryView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Scenario/ScenarioStoryView.swift
@@ -183,9 +183,9 @@ private extension ScenarioStoryView {
                 guard !isShowingAd else { return }
                 isShowingAd = true
                 Task {
-                    let success = await AdService.shared.showAdWithResult(.interstitial)
+                    let result = await AdService.shared.showAdWithResult(.interstitial)
                     isShowingAd = false
-                    if success {
+                    if result.success {
                         selected = ""
                         withAnimation(Animation.standard) {
                             manager.reselectChoice()

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Scenario/ScenarioStoryView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Scenario/ScenarioStoryView.swift
@@ -22,6 +22,7 @@ struct ScenarioStoryView: View {
     @State private var selected: String = ""
     @State private var finalEnding: Ending? = nil
     @State private var isShowingAd = false
+    @State private var adRewardFlowID: String?
 
     // 토스트 상태
     @State private var showCompletedToast = false
@@ -91,6 +92,7 @@ struct ScenarioStoryView: View {
                     ))
                 } else if let page = manager.currentPage {
                     eventButtonView(for: page)
+                        .onAppear { trackReselectOfferIfNeeded(for: page) }
                 }
             }
             .frame(maxHeight: .infinity, alignment: isEnding ? .top : .center)
@@ -180,17 +182,40 @@ private extension ScenarioStoryView {
             )
         case .result:
             EventButton(type: .reselect(onReselect: {
-                guard !isShowingAd else { return }
+                guard !isShowingAd, let flowID = adRewardFlowID else { return }
                 isShowingAd = true
+
+                AnalyticsService.shared.logAdWatchClicked(
+                    adRewardFlowID: flowID,
+                    adPlacement: .reselectionReward,
+                    rewardType: .reselect,
+                    rewardAmount: 0
+                )
+
                 Task {
                     let result = await AdService.shared.showAdWithResult(.interstitial)
                     isShowingAd = false
+                    adRewardFlowID = nil
+
                     if result.success {
+                        AnalyticsService.shared.logAdWatchCompleted(
+                            adRewardFlowID: flowID,
+                            adPlacement: .reselectionReward,
+                            rewardType: .reselect,
+                            rewardAmount: 0,
+                            adWatchDurationSec: result.watchDurationSec
+                        )
                         selected = ""
                         withAnimation(Animation.standard) {
                             manager.reselectChoice()
                             currentPageIndex = manager.currentPageIndex
                         }
+                        AnalyticsService.shared.logAdRewardClaimed(
+                            adRewardFlowID: flowID,
+                            adPlacement: .reselectionReward,
+                            rewardType: .reselect,
+                            rewardAmount: 0
+                        )
                     }
                 }
             }, onComplete: handleNextTap))
@@ -200,6 +225,19 @@ private extension ScenarioStoryView {
 
 // MARK: - 헬퍼
 private extension ScenarioStoryView {
+    func trackReselectOfferIfNeeded(for page: ScenarioPage) {
+        guard case .result = page.pageType, adRewardFlowID == nil else { return }
+
+        let flowID = AnalyticsService.shared.makeAdRewardFlowID()
+        adRewardFlowID = flowID
+        AnalyticsService.shared.logAdOfferViewed(
+            adRewardFlowID: flowID,
+            adPlacement: .reselectionReward,
+            rewardType: .reselect,
+            rewardAmount: 0
+        )
+    }
+
     func restoreEndingIfNeeded() {
         guard manager.currentScenario?.scenarioType == .final,
               let finalChoice = user.record.choiceHistory[.worldClassDeveloper] else { return }

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/ShopView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/ShopView.swift
@@ -161,16 +161,7 @@ private extension ShopView {
         let displayRate = hasBonus ? min(baseRate + 10, 100) : baseRate
         let priceText = ShopPurchaseHelper.createPriceText(for: item, shopSystem: shopSystem)
 
-        if !hasBonus, enhanceAdRewardFlowID == nil {
-            let flowID = AnalyticsService.shared.makeAdRewardFlowID()
-            enhanceAdRewardFlowID = flowID
-            AnalyticsService.shared.logAdOfferViewed(
-                adRewardFlowID: flowID,
-                adPlacement: .equipmentEnhance,
-                rewardType: .enhanceRateBoost,
-                rewardAmount: 0
-            )
-        }
+        trackEnhanceAdOfferIfNeeded(hasBonus: hasBonus)
 
         storePopup = StorePopup(
             type: .ad(
@@ -181,50 +172,12 @@ private extension ShopView {
                 confirmText: "강화",
                 cancelAction: {
                     storePopup = nil
-                    if !hasBonus, let flowID = enhanceAdRewardFlowID {
-                        AnalyticsService.shared.logAdOfferDismissed(
-                            adRewardFlowID: flowID,
-                            adPlacement: .equipmentEnhance,
-                            rewardType: .enhanceRateBoost,
-                            rewardAmount: 0,
-                            dismissReason: .close
-                        )
-                        enhanceAdRewardFlowID = nil
-                    }
+                    trackEnhanceAdDismissIfNeeded(hasBonus: hasBonus)
                 },
                 adAction: {
                     storePopup = nil
-                    guard let flowID = enhanceAdRewardFlowID else { return }
-
-                    AnalyticsService.shared.logAdWatchClicked(
-                        adRewardFlowID: flowID,
-                        adPlacement: .equipmentEnhance,
-                        rewardType: .enhanceRateBoost,
-                        rewardAmount: 0
-                    )
-
                     Task {
-                        let result = await AdService.shared.showAdWithResult(.interstitial)
-                        enhanceAdRewardFlowID = nil
-                        guard result.success else { return }
-
-                        AnalyticsService.shared.logAdWatchCompleted(
-                            adRewardFlowID: flowID,
-                            adPlacement: .equipmentEnhance,
-                            rewardType: .enhanceRateBoost,
-                            rewardAmount: 0,
-                            adWatchDurationSec: result.watchDurationSec
-                        )
-                        adBonusAppliedTypes.insert(typeKey)
-                        UserDefaults.standard.set(Array(adBonusAppliedTypes), forKey: Constant.UserDefaultsKey.equipmentAdBonus)
-                        showAdBonusToast = true
-                        AnalyticsService.shared.logAdRewardClaimed(
-                            adRewardFlowID: flowID,
-                            adPlacement: .equipmentEnhance,
-                            rewardType: .enhanceRateBoost,
-                            rewardAmount: 0
-                        )
-                        showEquipmentEnhancePopup(item: item, equipment: equipment, scrollProxy: scrollProxy)
+                        await handleEnhanceAdWatch(item: item, equipment: equipment, scrollProxy: scrollProxy, typeKey: typeKey)
                     }
                 },
                 confirmAction: {
@@ -237,6 +190,65 @@ private extension ShopView {
             price: priceText,
             rateHighlighted: hasBonus
         )
+    }
+
+    func trackEnhanceAdOfferIfNeeded(hasBonus: Bool) {
+        guard !hasBonus, enhanceAdRewardFlowID == nil else { return }
+
+        let flowID = AnalyticsService.shared.makeAdRewardFlowID()
+        enhanceAdRewardFlowID = flowID
+        AnalyticsService.shared.logAdOfferViewed(
+            adRewardFlowID: flowID,
+            adPlacement: .equipmentEnhance,
+            rewardType: .enhanceRateBoost,
+            rewardAmount: 0
+        )
+    }
+
+    func trackEnhanceAdDismissIfNeeded(hasBonus: Bool) {
+        guard !hasBonus, let flowID = enhanceAdRewardFlowID else { return }
+
+        AnalyticsService.shared.logAdOfferDismissed(
+            adRewardFlowID: flowID,
+            adPlacement: .equipmentEnhance,
+            rewardType: .enhanceRateBoost,
+            rewardAmount: 0,
+            dismissReason: .close
+        )
+        enhanceAdRewardFlowID = nil
+    }
+
+    func handleEnhanceAdWatch(item: DisplayItem, equipment: Equipment, scrollProxy: ScrollViewProxy?, typeKey: String) async {
+        guard let flowID = enhanceAdRewardFlowID else { return }
+
+        AnalyticsService.shared.logAdWatchClicked(
+            adRewardFlowID: flowID,
+            adPlacement: .equipmentEnhance,
+            rewardType: .enhanceRateBoost,
+            rewardAmount: 0
+        )
+
+        let result = await AdService.shared.showAdWithResult(.interstitial)
+        enhanceAdRewardFlowID = nil
+        guard result.success else { return }
+
+        AnalyticsService.shared.logAdWatchCompleted(
+            adRewardFlowID: flowID,
+            adPlacement: .equipmentEnhance,
+            rewardType: .enhanceRateBoost,
+            rewardAmount: 0,
+            adWatchDurationSec: result.watchDurationSec
+        )
+        adBonusAppliedTypes.insert(typeKey)
+        UserDefaults.standard.set(Array(adBonusAppliedTypes), forKey: Constant.UserDefaultsKey.equipmentAdBonus)
+        showAdBonusToast = true
+        AnalyticsService.shared.logAdRewardClaimed(
+            adRewardFlowID: flowID,
+            adPlacement: .equipmentEnhance,
+            rewardType: .enhanceRateBoost,
+            rewardAmount: 0
+        )
+        showEquipmentEnhancePopup(item: item, equipment: equipment, scrollProxy: scrollProxy)
     }
 
     /// 실제 구매 실행

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/ShopView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/ShopView.swift
@@ -171,8 +171,8 @@ private extension ShopView {
                 adAction: {
                     storePopup = nil
                     Task {
-                        let watched = await AdService.shared.showAdWithResult(.interstitial)
-                        guard watched else { return }
+                        let result = await AdService.shared.showAdWithResult(.interstitial)
+                        guard result.success else { return }
                         adBonusAppliedTypes.insert(typeKey)
                         UserDefaults.standard.set(Array(adBonusAppliedTypes), forKey: Constant.UserDefaultsKey.equipmentAdBonus)
                         showAdBonusToast = true

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/ShopView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/ShopView.swift
@@ -39,6 +39,7 @@ struct ShopView: View {
         let saved = UserDefaults.standard.stringArray(forKey: Constant.UserDefaultsKey.equipmentAdBonus) ?? []
         return Set(saved)
     }()
+    @State private var enhanceAdRewardFlowID: String?
 
     @Binding var storePopup: StorePopup?
     @Binding var noticePopup: NoticePopup?
@@ -160,6 +161,17 @@ private extension ShopView {
         let displayRate = hasBonus ? min(baseRate + 10, 100) : baseRate
         let priceText = ShopPurchaseHelper.createPriceText(for: item, shopSystem: shopSystem)
 
+        if !hasBonus, enhanceAdRewardFlowID == nil {
+            let flowID = AnalyticsService.shared.makeAdRewardFlowID()
+            enhanceAdRewardFlowID = flowID
+            AnalyticsService.shared.logAdOfferViewed(
+                adRewardFlowID: flowID,
+                adPlacement: .equipmentEnhance,
+                rewardType: .enhanceRateBoost,
+                rewardAmount: 0
+            )
+        }
+
         storePopup = StorePopup(
             type: .ad(
                 successRate: displayRate,
@@ -167,15 +179,51 @@ private extension ShopView {
                 cancelText: "취소",
                 adText: "확률 UP",
                 confirmText: "강화",
-                cancelAction: { storePopup = nil },
+                cancelAction: {
+                    storePopup = nil
+                    if !hasBonus, let flowID = enhanceAdRewardFlowID {
+                        AnalyticsService.shared.logAdOfferDismissed(
+                            adRewardFlowID: flowID,
+                            adPlacement: .equipmentEnhance,
+                            rewardType: .enhanceRateBoost,
+                            rewardAmount: 0,
+                            dismissReason: .close
+                        )
+                        enhanceAdRewardFlowID = nil
+                    }
+                },
                 adAction: {
                     storePopup = nil
+                    guard let flowID = enhanceAdRewardFlowID else { return }
+
+                    AnalyticsService.shared.logAdWatchClicked(
+                        adRewardFlowID: flowID,
+                        adPlacement: .equipmentEnhance,
+                        rewardType: .enhanceRateBoost,
+                        rewardAmount: 0
+                    )
+
                     Task {
                         let result = await AdService.shared.showAdWithResult(.interstitial)
+                        enhanceAdRewardFlowID = nil
                         guard result.success else { return }
+
+                        AnalyticsService.shared.logAdWatchCompleted(
+                            adRewardFlowID: flowID,
+                            adPlacement: .equipmentEnhance,
+                            rewardType: .enhanceRateBoost,
+                            rewardAmount: 0,
+                            adWatchDurationSec: result.watchDurationSec
+                        )
                         adBonusAppliedTypes.insert(typeKey)
                         UserDefaults.standard.set(Array(adBonusAppliedTypes), forKey: Constant.UserDefaultsKey.equipmentAdBonus)
                         showAdBonusToast = true
+                        AnalyticsService.shared.logAdRewardClaimed(
+                            adRewardFlowID: flowID,
+                            adPlacement: .equipmentEnhance,
+                            rewardType: .enhanceRateBoost,
+                            rewardAmount: 0
+                        )
                         showEquipmentEnhancePopup(item: item, equipment: equipment, scrollProxy: scrollProxy)
                     }
                 },

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/SkillView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/SkillView.swift
@@ -16,6 +16,8 @@ struct SkillView: View {
     @Binding var noticePopup: NoticePopup?
     let adRewardNow: Date
 
+    @State private var adRewardFlowID: String?
+
     init(
         user: User,
         careerSystem: CareerSystem?,
@@ -32,13 +34,25 @@ struct SkillView: View {
     var skillAdItemRow: some View {
         let isActive = SkillAdRewardManager.isRewardActive(user: user, now: adRewardNow)
         let canUseToday = SkillAdRewardManager.canUseRewardToday(user: user, now: adRewardNow)
+        let buttonState = adRewardButtonState(isActive: isActive, canUseToday: canUseToday)
+
+        if buttonState == .default, adRewardFlowID == nil {
+            let flowID = AnalyticsService.shared.makeAdRewardFlowID()
+            adRewardFlowID = flowID
+            AnalyticsService.shared.logAdOfferViewed(
+                adRewardFlowID: flowID,
+                adPlacement: .skillReward,
+                rewardType: .skillBoost,
+                rewardAmount: 0
+            )
+        }
 
         return ItemRow(
             imageName: "adBoost",
             title: "업무 효율 대박",
             description: "5분간 피버타임 두배 (X1, X2, X4)",
             buttonType: .singleLine(text: isActive ? "사용중" : "광고보기", icon: .ad),
-            buttonState: adRewardButtonState(isActive: isActive, canUseToday: canUseToday),
+            buttonState: buttonState,
             action: {
                 Task { await handleWatchAd() }
             }
@@ -109,13 +123,36 @@ private extension SkillView {
         let isActive = SkillAdRewardManager.isRewardActive(user: user, now: adRewardNow)
         let canUseToday = SkillAdRewardManager.canUseRewardToday(user: user, now: adRewardNow)
         guard adRewardButtonState(isActive: isActive, canUseToday: canUseToday) == .default else { return }
+        guard let flowID = adRewardFlowID else { return }
+
+        AnalyticsService.shared.logAdWatchClicked(
+            adRewardFlowID: flowID,
+            adPlacement: .skillReward,
+            rewardType: .skillBoost,
+            rewardAmount: 0
+        )
 
         let result = await AdService.shared.showAdWithResult(.interstitial)
+        adRewardFlowID = nil
+
         if result.success {
+            AnalyticsService.shared.logAdWatchCompleted(
+                adRewardFlowID: flowID,
+                adPlacement: .skillReward,
+                rewardType: .skillBoost,
+                rewardAmount: 0,
+                adWatchDurationSec: result.watchDurationSec
+            )
             noticePopup = NoticePopup(
                 type: .default(buttonText: "확인", action: {
                     noticePopup = nil
                     SkillAdRewardManager.grantReward(user: user)
+                    AnalyticsService.shared.logAdRewardClaimed(
+                        adRewardFlowID: flowID,
+                        adPlacement: .skillReward,
+                        rewardType: .skillBoost,
+                        rewardAmount: 0
+                    )
                 }),
                 title: "보상 완료",
                 text: "\(Int(Policy.Ad.SkillReward.rewardDuration / 60))분간 게임 재화를 \(Int(Policy.Ad.SkillReward.rewardMultiplier))배로 획득합니다."

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/SkillView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/SkillView.swift
@@ -110,8 +110,8 @@ private extension SkillView {
         let canUseToday = SkillAdRewardManager.canUseRewardToday(user: user, now: adRewardNow)
         guard adRewardButtonState(isActive: isActive, canUseToday: canUseToday) == .default else { return }
 
-        let success = await AdService.shared.showAdWithResult(.interstitial)
-        if success {
+        let result = await AdService.shared.showAdWithResult(.interstitial)
+        if result.success {
             noticePopup = NoticePopup(
                 type: .default(buttonText: "확인", action: {
                     noticePopup = nil

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Work/Game/QuizGameView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Work/Game/QuizGameView.swift
@@ -15,6 +15,7 @@ struct QuizGameView: View {
     @State private var showQuizAdPopup: Bool = false
     @State private var showQuizRewardPopup: Bool = false
     @State private var finalDiamondsEarned: Int = 0
+    @State private var adRewardFlowID: String?
 
     init(user: User) {
         _quizGame = State(initialValue: QuizGame(user: user))
@@ -144,6 +145,14 @@ struct QuizGameView: View {
                 if quizGame.phase == .showingExplanation {
                     if quizGame.state.nextButtonTitle == "보상받기" {
                         showQuizAdPopup = true
+                        let flowID = AnalyticsService.shared.makeAdRewardFlowID()
+                        adRewardFlowID = flowID
+                        AnalyticsService.shared.logAdOfferViewed(
+                            adRewardFlowID: flowID,
+                            adPlacement: .quizReward,
+                            rewardType: .diamond,
+                            rewardAmount: quizGame.state.totalDiamondsEarned
+                        )
                     } else {
                         quizGame.proceedToNextQuestion()
                     }
@@ -167,6 +176,16 @@ struct QuizGameView: View {
                             adText: "2배 얻기",
                             cancelAction: {
                                 showQuizAdPopup = false
+                                if let flowID = adRewardFlowID {
+                                    AnalyticsService.shared.logAdOfferDismissed(
+                                        adRewardFlowID: flowID,
+                                        adPlacement: .quizReward,
+                                        rewardType: .diamond,
+                                        rewardAmount: quizGame.state.totalDiamondsEarned,
+                                        dismissReason: .close
+                                    )
+                                    adRewardFlowID = nil
+                                }
                                 quizGame.completeGame(multiplier: 1.0)
                                 dismiss()
                             },
@@ -209,11 +228,38 @@ struct QuizGameView: View {
 private extension QuizGameView {
     func handleWatchAd() async {
         showQuizAdPopup = false
+        guard let flowID = adRewardFlowID else { return }
+        let baseDiamonds = quizGame.state.totalDiamondsEarned
+
+        AnalyticsService.shared.logAdWatchClicked(
+            adRewardFlowID: flowID,
+            adPlacement: .quizReward,
+            rewardType: .diamond,
+            rewardAmount: baseDiamonds
+        )
+
         let result = await AdService.shared.showAdWithResult(.interstitial)
+        adRewardFlowID = nil
+
         if result.success {
-            finalDiamondsEarned = quizGame.state.totalDiamondsEarned * 2
+            finalDiamondsEarned = baseDiamonds * 2
+            let earnedByAd = finalDiamondsEarned - baseDiamonds
+
+            AnalyticsService.shared.logAdWatchCompleted(
+                adRewardFlowID: flowID,
+                adPlacement: .quizReward,
+                rewardType: .diamond,
+                rewardAmount: earnedByAd,
+                adWatchDurationSec: result.watchDurationSec
+            )
             quizGame.completeGame(multiplier: 2.0)
             showQuizRewardPopup = true
+            AnalyticsService.shared.logAdRewardClaimed(
+                adRewardFlowID: flowID,
+                adPlacement: .quizReward,
+                rewardType: .diamond,
+                rewardAmount: earnedByAd
+            )
         } else {
             quizGame.completeGame(multiplier: 1.0)
             dismiss()

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Work/Game/QuizGameView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Work/Game/QuizGameView.swift
@@ -209,8 +209,8 @@ struct QuizGameView: View {
 private extension QuizGameView {
     func handleWatchAd() async {
         showQuizAdPopup = false
-        let success = await AdService.shared.showAdWithResult(.interstitial)
-        if success {
+        let result = await AdService.shared.showAdWithResult(.interstitial)
+        if result.success {
             finalDiamondsEarned = quizGame.state.totalDiamondsEarned * 2
             quizGame.completeGame(multiplier: 2.0)
             showQuizRewardPopup = true


### PR DESCRIPTION
## 연관된 이슈

- [KAN-70](https://devvup.atlassian.net/browse/KAN-70)
- [KAN-158](https://devvup.atlassian.net/browse/KAN-158)
- [구글 시트](https://docs.google.com/spreadsheets/d/1VU8dY-Zloze5VxHVhu0zegG4aN0ohfmb2Yxj-xP6XrU/edit?gid=1888550940#gid=1888550940)

## 작업 내용 및 고민 내용

### NSUserTrackingUsageDescription 문구 수정 (KAN-158)

- `개인화된 광고 제공 목적으로 사용됩니다.` → `맞춤형 광고 제공 및 광고 성과 측정을 위해 사용됩니다.`

### 광고 보상 흐름에 GA 이벤트 연결 (KAN-70)

#### 1. 선행작업
- `AdService.showAdWithResult`의 반환 타입을
`Bool` → `AdShowResult(success, watchDurationSec)`로 변경하여 광고 순수 시청 시간 측정 가능하도록 함
- `AdRewardType`에 `skillBoost`, `enhanceRateBoost` 추가

#### 2. 광고 부분에 GA 이벤트 연결
- **`skillReward`** (SkillView.swift)
  - 업무 효율 버프 광고: ad_offer_viewed, ad_watch_clicked, ad_watch_completed, ad_reward_claimed (4개, 취소 동작 없어 ad_offer_dismissed 제외)
- **`reselectionReward`** (ScenarioStoryView.swift)
  - 시나리오 재선택 광고: 위와 동일하게 4개 (취소 동작 없음)
- **`quizReward`** (QuizGameView.swift)
  - 퀴즈 보상 2배 광고: 5개 전체
- **`consumable`** (MainView.swift)
  - 음료(커피/박하스) 소진 시 광고: 5개 전체
- **`workExit`** (MainView.swift)
  - 업무 퇴장 보너스 광고: 5개 전체
- **`offlineReward`** (MainView.swift)
  - 오프라인 보상 광고: 5개 전체
- **`equipmentEnhance`** (ShopView.swift)
  - 장비 강화 확률업 광고: 5개 전체

### 설계 특이 사항

- **시청 시간 측정 위치**
  - `AdService.showAdWithResult` 내부에서 `ads.showWithResult()` 호출 직전/직후로만 시간을 측정해,
  ATT(앱 추적 권한) 응답 대기 시간이 시청 시간에 섞이지 않도록 함
- **ad_offer_dismissed의 적용 범위**
  - "광고 제안 노출 후 클릭 없이 거절"한 경우만 해당.
  - 시청 도중 이탈은 별도 이벤트 영역으로 보고 이번 범위에서 제외.
  - 명시적 취소 버튼이 없는 skillReward/reselectionReward는 이 이벤트 자체가 발생하지 않음
