### PR TITLE
스킬/시나리오 화면의 보상형 광고 미재생 문제를 해결합니다.

### DIFF
--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Scenario/ScenarioStoryView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Scenario/ScenarioStoryView.swift
@@ -103,7 +103,6 @@ struct ScenarioStoryView: View {
                     ))
                 } else if let page = manager.currentPage {
                     eventButtonView(for: page)
-                        .onAppear { trackReselectOfferIfNeeded(for: page) }
                 }
             }
             .frame(maxHeight: .infinity, alignment: isEnding ? .top : .center)
@@ -247,6 +246,7 @@ private extension ScenarioStoryView {
                 SoundService.shared.trigger(.click)
                 handleNextTap()
             }))
+            .onAppear { trackReselectOfferIfNeeded(for: page) }
         }
     }
 }

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/SkillView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/SkillView.swift
@@ -36,17 +36,6 @@ struct SkillView: View {
         let canUseToday = SkillAdRewardManager.canUseRewardToday(user: user, now: adRewardNow)
         let buttonState = adRewardButtonState(isActive: isActive, canUseToday: canUseToday)
 
-        if buttonState == .default, adRewardFlowID == nil {
-            let flowID = AnalyticsService.shared.makeAdRewardFlowID()
-            adRewardFlowID = flowID
-            AnalyticsService.shared.logAdOfferViewed(
-                adRewardFlowID: flowID,
-                adPlacement: .skillReward,
-                rewardType: .skillBoost,
-                rewardAmount: 0
-            )
-        }
-
         return ItemRow(
             imageName: "adBoost",
             title: "업무 효율 대박",
@@ -58,6 +47,9 @@ struct SkillView: View {
                 Task { await handleWatchAd() }
             }
         )
+        .onAppear {
+            trackAdOfferIfNeeded(buttonState: buttonState)
+        }
     }
 
     var body: some View {
@@ -163,6 +155,19 @@ private extension SkillView {
                 text: "\(Int(Policy.Ad.SkillReward.rewardDuration / 60))분간 게임 재화를 \(Int(Policy.Ad.SkillReward.rewardMultiplier))배로 획득합니다."
             )
         }
+    }
+
+    func trackAdOfferIfNeeded(buttonState: ItemButton.ItemButtonState) {
+        guard buttonState == .default, adRewardFlowID == nil else { return }
+
+        let flowID = AnalyticsService.shared.makeAdRewardFlowID()
+        adRewardFlowID = flowID
+        AnalyticsService.shared.logAdOfferViewed(
+            adRewardFlowID: flowID,
+            adPlacement: .skillReward,
+            rewardType: .skillBoost,
+            rewardAmount: 0
+        )
     }
 }
 


### PR DESCRIPTION
## 1. SkillView — 스킬 광고보기 버튼

### 오류

"업무 효율 대박" 카드의 "광고보기" 버튼을 눌러도 광고가 재생되지 않음.

### 원인

<img width="1328" height="626" alt="image" src="https://github.com/user-attachments/assets/aa5c1e4b-2710-4e5a-9686-3fbbde390fd2" />

- `adRewardFlowID` 생성과 분석 로그 호출이 `skillAdItemRow`라는 computed view property(`body` 평가 경로) 안에 직접 들어 있는 상황
- SwiftUI에서 이 경로는 뷰를 읽기만 해야 하는데, 여기서 `@State`(`adRewardFlowID`)를 직접 변경하고 있어 "Modifying state during view update, this will cause undefined behavior" 경고가 발생
- 이로 인해 렌더링 타이밍이 꼬여 실제 버튼 탭 시점에 `adRewardFlowID`가 `nil`인 상태로 `handleWatchAd()`가 호출되고,
그 함수의 `guard let flowID = adRewardFlowID else { return }`에서 조용히 멈춰버림

### 해결

- `flowID` 생성/로깅 로직을 `trackAdOfferIfNeeded(buttonState:)` 함수로 분리하여 `ItemRow`의 `.onAppear` 콜백에서 호출하도록 변경
(부수효과(상태 변경)를 `body` 평가 경로에서 완전히 빼내고, SwiftUI가 부수효과를 허용하는 시점(`onAppear`)으로 이동)

---

## 2. ScenarioStoryView — 시나리오 결과 화면 "다시 선택" 버튼

### 오류

선택형 시나리오에서 결과 화면이 뜨고 "다시 선택" 버튼을 눌러도 클릭음만 나고 광고가 재생되지 않음.

### 원인
- `trackReselectOfferIfNeeded(for:)` 호출이 `eventButtonView(for: page)` 바깥,
즉 `.story`/`.choice`/`.result` 모든 페이지 타입에 공통으로 걸린 `.onAppear`에 있었음
- `.choice` 페이지에서 `.result` 페이지로 전환될 때, 두 페이지가 같은 호출 위치(`eventButtonView(for: page)`)에서
만들어지는 뷰라 SwiftUI가 이를 "새로 나타난 뷰"로 인식하지 못해 `.onAppear`가 재발동하지 않음
- 그 결과 `.result` 페이지에 도달해도 `adRewardFlowID`가 한 번도 세팅되지 않아,
"다시 선택" 탭 시 `guard !isShowingAd, let flowID = adRewardFlowID else { return }`에서 막힘

### 해결
- `.onAppear { trackReselectOfferIfNeeded(for: page) }`를 공통 위치에서 떼어내,
`eventButtonView`의 `switch` 문 안 `.result` case에서 만드는 `EventButton` 자체에 직접 부착
- `.result` case로 전환되는 시점에 SwiftUI가 명확히 다른 분기로 인식해 `.onAppear`가 확실히 발동하도록 함

---

##  리뷰 요구사항

해당 브랜치에서 빌드하여 광고 플로우가 잘 해결됐는지 확인 부탁드립니다!