### PR TITLE
강제업데이트 기능 구현

### DIFF
--- a/SoloDeveloperTraining/SoloDeveloperTraining/App/SoloDeveloperTrainingApp.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/App/SoloDeveloperTrainingApp.swift
@@ -49,6 +49,7 @@ struct SoloDeveloperTrainingApp: App {
     @State private var errorMessage: String = ""
     @State private var isPolicyLoading = true
     @State private var hasPolicyError = false
+    @State private var updateType: AppUpdateType = .none
     @Environment(\.scenePhase) private var scenePhase
 
     private let userRepository: UserRepository = FileManagerUserRepository()
@@ -117,6 +118,17 @@ private extension SoloDeveloperTrainingApp {
         }
         .overlay {
             errorPopupOverlay
+        }
+        .overlay {
+            updateOverlay
+        }
+        .task {
+            let type = await AppUpdateChecker.checkUpdate()
+            if type == .force {
+                updateType = .force
+            } else if type == .optional && !AppUpdateChecker.isOptionalUpdateSnoozed() {
+                updateType = .optional
+            }
         }
         .onAppear {
             guard user == nil else { return }
@@ -197,6 +209,40 @@ private extension SoloDeveloperTrainingApp {
     }
 
     // MARK: - Overlays
+
+    @ViewBuilder
+    var updateOverlay: some View {
+        if updateType == .force {
+            ZStack {
+                Color.black300PopUpDimStatusBar.ignoresSafeArea()
+                NoticePopup(
+                    type: .default(
+                        buttonText: "업데이트",
+                        action: { AppUpdateChecker.openAppStore() }
+                    ),
+                    title: "업데이트 안내",
+                    text: "원활한 앱 사용을 위해서 업데이트가 필요합니다.\n지금 바로 업데이트를 진행해주세요."
+                )
+            }
+        } else if updateType == .optional {
+            ZStack {
+                Color.black300PopUpDimStatusBar.ignoresSafeArea()
+                NoticePopup(
+                    type: .confirm(
+                        cancelText: "다음에",
+                        confirmText: "업데이트",
+                        cancelAction: {
+                            AppUpdateChecker.snoozeOptionalUpdate()
+                            updateType = .none
+                        },
+                        confirmAction: { AppUpdateChecker.openAppStore() }
+                    ),
+                    title: "업데이트 안내",
+                    text: "원활한 앱 사용을 위해서 업데이트가 필요합니다.\n지금 바로 업데이트를 진행해주세요."
+                )
+            }
+        }
+    }
 
     @ViewBuilder
     var errorPopupOverlay: some View {

--- a/SoloDeveloperTraining/SoloDeveloperTraining/App/Storages/AppPreferences.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/App/Storages/AppPreferences.swift
@@ -35,6 +35,9 @@ final class AppPreferences {
 
         /// 업데이트 보상
         static let hasClaimedGameResetReward = "hasClaimedGameResetReward"
+
+        /// 선택 업데이트 스누즈 만료 시각
+        static let optionalUpdateSnoozedUntil = "optionalUpdateSnoozedUntil"
     }
 
     private let storage = UserDefaultsStorage()
@@ -88,6 +91,11 @@ extension AppPreferences {
     var hasClaimedGameResetReward: Bool {
         get { storage.bool(key: Key.hasClaimedGameResetReward) }
         set { storage.set(newValue, forKey: Key.hasClaimedGameResetReward) }
+    }
+
+    var optionalUpdateSnoozedUntil: Date? {
+        get { storage.any(key: Key.optionalUpdateSnoozedUntil) as? Date }
+        set { storage.set(newValue as Any, forKey: Key.optionalUpdateSnoozedUntil) }
     }
 
 }

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Utility/AppUpdateChecker.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Utility/AppUpdateChecker.swift
@@ -1,0 +1,87 @@
+//
+//  AppUpdateChecker.swift
+//  SoloDeveloperTraining
+//
+
+import Foundation
+import UIKit
+
+enum AppUpdateType {
+    case none
+    case optional
+    case force
+}
+
+struct AppUpdateChecker {
+
+    private enum UserDefaultsKey {
+        static let optionalUpdateSnoozedUntil = "optionalUpdateSnoozedUntil"
+    }
+
+    private static let appStoreID = "6758282441"
+    private static let appStoreURL = URL(string: "https://apps.apple.com/kr/app/id\(appStoreID)")!
+    private static let lookupURL = URL(string: "https://itunes.apple.com/lookup?id=\(appStoreID)&country=kr")!
+
+    // MARK: - Public
+
+    static func checkUpdate() async -> AppUpdateType {
+        guard let storeVersion = await fetchStoreVersion() else { return .none }
+        let currentVersion = currentAppVersion()
+        return compareVersions(current: currentVersion, store: storeVersion)
+    }
+
+    static func openAppStore() {
+        UIApplication.shared.open(appStoreURL)
+    }
+
+    static func snoozeOptionalUpdate() {
+        let snoozedUntil = Date().addingTimeInterval(60 * 60 * 24 * 7)
+        UserDefaults.standard.set(snoozedUntil, forKey: UserDefaultsKey.optionalUpdateSnoozedUntil)
+    }
+
+    static func isOptionalUpdateSnoozed() -> Bool {
+        guard let snoozedUntil = UserDefaults.standard.object(forKey: UserDefaultsKey.optionalUpdateSnoozedUntil) as? Date else {
+            return false
+        }
+        return Date() < snoozedUntil
+    }
+
+    // MARK: - Private
+
+    private static func fetchStoreVersion() async -> String? {
+        guard let (data, _) = try? await URLSession.shared.data(from: lookupURL),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let results = json["results"] as? [[String: Any]],
+              let first = results.first,
+              let version = first["version"] as? String else {
+            return nil
+        }
+        return version
+    }
+
+    private static func currentAppVersion() -> String {
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.0"
+    }
+
+    private static func compareVersions(current: String, store: String) -> AppUpdateType {
+        let currentParts = current.split(separator: ".").compactMap { Int($0) }
+        let storeParts = store.split(separator: ".").compactMap { Int($0) }
+
+        let currentMajor = currentParts.count > 0 ? currentParts[0] : 0
+        let storeMajor = storeParts.count > 0 ? storeParts[0] : 0
+
+        let currentMinor = currentParts.count > 1 ? currentParts[1] : 0
+        let storeMinor = storeParts.count > 1 ? storeParts[1] : 0
+
+        let currentPatch = currentParts.count > 2 ? currentParts[2] : 0
+        let storePatch = storeParts.count > 2 ? storeParts[2] : 0
+
+        if storeMajor > currentMajor {
+            return .force
+        }
+        if storeMinor > currentMinor || storePatch > currentPatch {
+            return .optional
+        }
+        return .none
+    }
+}

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Utility/AppUpdateChecker.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Utility/AppUpdateChecker.swift
@@ -14,10 +14,6 @@ enum AppUpdateType {
 
 struct AppUpdateChecker {
 
-    private enum UserDefaultsKey {
-        static let optionalUpdateSnoozedUntil = "optionalUpdateSnoozedUntil"
-    }
-
     private static let appStoreID = "6758282441"
     private static let appStoreURL = URL(string: "https://apps.apple.com/kr/app/id\(appStoreID)")!
     private static let lookupURL = URL(string: "https://itunes.apple.com/lookup?id=\(appStoreID)&country=kr")!
@@ -35,14 +31,11 @@ struct AppUpdateChecker {
     }
 
     static func snoozeOptionalUpdate() {
-        let snoozedUntil = Date().addingTimeInterval(60 * 60 * 24 * 7)
-        UserDefaults.standard.set(snoozedUntil, forKey: UserDefaultsKey.optionalUpdateSnoozedUntil)
+        AppPreferences.shared.optionalUpdateSnoozedUntil = Date().addingTimeInterval(60 * 60 * 24 * 7)
     }
 
     static func isOptionalUpdateSnoozed() -> Bool {
-        guard let snoozedUntil = UserDefaults.standard.object(forKey: UserDefaultsKey.optionalUpdateSnoozedUntil) as? Date else {
-            return false
-        }
+        guard let snoozedUntil = AppPreferences.shared.optionalUpdateSnoozedUntil else { return false }
         return Date() < snoozedUntil
     }
 


### PR DESCRIPTION
## 연관된 이슈

- [#KAN-156](https://devvup.atlassian.net/jira/software/projects/KAN/boards/1/backlog?selectedIssue=KAN-156)

## 작업 내용

### 앱 업데이트 체크 (`AppUpdateChecker.swift`)

- iTunes Lookup API로 앱스토어 최신 버전 조회
- 번들 마케팅 버전과 시멘틱 버저닝 비교
  - major 변경 → 강제 업데이트
  - minor / patch 변경 → 선택 업데이트
- 선택 업데이트 "다음에" 시 7일 스누즈 (UserDefaults)
- 스누즈 기간 중 강제 업데이트 조건 충족 시 강제 업데이트로 전환

### 업데이트 오버레이 (`SoloDeveloperTrainingApp.swift`)

- 앱 시작 시 버전 체크 후 `updateType` 상태로 관리
- 강제 업데이트: 단일 "업데이트" 버튼만 표시, 화면 진입 차단
- 선택 업데이트: "다음에" / "업데이트" 버튼 표시
- 앱스토어 URL: `https://apps.apple.com/kr/app/id6758282441`

---

## 스크린샷
<img width="300" alt="image" src="https://github.com/user-attachments/assets/26be029d-f00b-4081-b197-eb0e8f130a30" />

<img width="300" alt="image" src="https://github.com/user-attachments/assets/0121ccb1-108c-49f7-9a3d-bbf988d9121a" />

## 확인해주세요
- 기존에 사용하던 코드는 추상화 및 여러겹의 레이어 구조를 사용하고 있어 직접 사용하기는 무리가 있다고 판단하여 가벼운 형태로 구성하였습니다.
- 시뮬레이터에는 앱스토어가 설치되어 있지 않기 때문에 실기기로 본앱의 마케팅 버전을 수정하면서 확인 부탁드립니다!
- 유저가 업데이트를 선택할 수 있는 경우 진입마다 업데이트를 물어보는건지 관련 문서를 찾아 볼 수 없어서 7일 동안 얼럿이 나오지 않게 하였습니다.