### PR TITLE
퀴즈화면의 ItemLabel 컴포넌트에 align 값을 추가합니다.

### DIFF
--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Work/Game/QuizGameView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Work/Game/QuizGameView.swift
@@ -91,7 +91,7 @@ struct QuizGameView: View {
     private var questionSection: some View {
         VStack(spacing: TokenSpacing.xl) {
             HStack(spacing: 0) {
-                ItemLabel(text: quizGame.currentQuestion?.question ?? "", font: .body, color: .black300)
+                ItemLabel(text: quizGame.currentQuestion?.question ?? "", font: .body, color: .black300, textAlignment: .leading)
                     .fixedSize(horizontal: false, vertical: true)
                 Spacer()
             }
@@ -112,7 +112,8 @@ struct QuizGameView: View {
                             "정답\n\(quizGame.currentQuestion?.explanation ?? "")" :
                             "오답\n\(quizGame.currentQuestion?.explanation ?? "")",
                         font: .label,
-                        color: quizGame.currentAnswerResult?.isCorrect == true ? .accentGreen : .accentRed
+                        color: quizGame.currentAnswerResult?.isCorrect == true ? .accentGreen : .accentRed,
+                        textAlignment: .leading
                     )
                     .fixedSize(horizontal: false, vertical: true)
                     Spacer()


### PR DESCRIPTION
## 작업 내용

DUDesignSystem에서 `ItemLabel` 컴포넌트의 Align 속성이 추가됨에 따라 퀴즈 화면에서 수정이 있었습니다.
- 문제 영역의 `ItemLabel(..., textAlignment: .center)` -> `ItemLabel(..., textAlignment: .leading)`
- 해설 영역의 `ItemLabel(..., textAlignment: .center)` -> `ItemLabel(..., textAlignment: .leading)`

---

<img width="1186" height="500" alt="image" src="https://github.com/user-attachments/assets/ef0416ac-defc-49a8-9e8f-e637b2ae9984" />
