### PR TITLE
ItemLabel 컴포넌트 사용처의 align 속성을 변경합니다.

### DIFF
--- a/DUDesignSystem/Sources/DUDesignSystem/Components/Rows/CareerRow.swift
+++ b/DUDesignSystem/Sources/DUDesignSystem/Components/Rows/CareerRow.swift
@@ -65,7 +65,7 @@ public struct CareerRow: View {
                         ItemLabel(text: "완료", font: .label, color: .black300)
                     }
                 }
-                ItemLabel(text: description, font: .label, color: .black300)
+                ItemLabel(text: description, font: .label, color: .black300, textAlignment: .leading)
             }
             .opacity(textOpacity)
             .frame(maxWidth: .infinity, alignment: .leading)

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Work/Game/QuizGameView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Work/Game/QuizGameView.swift
@@ -91,7 +91,7 @@ struct QuizGameView: View {
     private var questionSection: some View {
         VStack(spacing: TokenSpacing.xl) {
             HStack(spacing: 0) {
-                ItemLabel(text: quizGame.currentQuestion?.question ?? "", font: .body, color: .black300)
+                ItemLabel(text: quizGame.currentQuestion?.question ?? "", font: .body, color: .black300, textAlignment: .leading)
                     .fixedSize(horizontal: false, vertical: true)
                 Spacer()
             }
@@ -112,7 +112,8 @@ struct QuizGameView: View {
                             "정답\n\(quizGame.currentQuestion?.explanation ?? "")" :
                             "오답\n\(quizGame.currentQuestion?.explanation ?? "")",
                         font: .label,
-                        color: quizGame.currentAnswerResult?.isCorrect == true ? .accentGreen : .accentRed
+                        color: quizGame.currentAnswerResult?.isCorrect == true ? .accentGreen : .accentRed,
+                        textAlignment: .leading
                     )
                     .fixedSize(horizontal: false, vertical: true)
                     Spacer()


### PR DESCRIPTION
## 연관된 이슈

- [KAN-171](https://devvup.atlassian.net/browse/KAN-171)
- [ItemLabel 컴포넌트에 textAlignment 속성이 추가된 PR](https://github.com/boostcampwm2025/iOS01-Hmm/pull/334)

## 작업 내용

- [ItemLabel 컴포넌트에 textAlignment 속성이 추가된 PR](https://github.com/boostcampwm2025/iOS01-Hmm/pull/334)에서 `textAlignment`의 `default` 값을 `.center`로 설정하였습니다.  
- 컴포넌트 및 View 내부에서 `textAlignment`가 `.center`가 아닌 `leading`인 부분을 반영하였습니다.

### 1. Quiz 화면

문제 및 해설 영역을 leading으로 설정하였습니다.

### 2. CareerPopupView (CareerRow 컴포넌트)

CareerPopupView에서 보여지는 커리어 description의 정렬을 leading으로 설정하였습니다.

## 스크린샷

| 퀴즈 화면 | 커리어 화면 |
|---|---|
| <img  height="600" alt="image" src="https://github.com/user-attachments/assets/46bfc82e-c066-4752-9115-459e8711481a" /> | <img height="600" alt="image" src="https://github.com/user-attachments/assets/5d8c0377-1ee9-4af3-8b10-3179b82a4960" /> |