### PR TITLE
본 앱 TestFlight/App Store 자동 배포 CD를 구축합니다.

### DIFF
--- a/.github/workflows/app-appstore-cd.yml
+++ b/.github/workflows/app-appstore-cd.yml
@@ -1,0 +1,164 @@
+name: App AppStore CD
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  deploy:
+    name: Deploy SoloDeveloperTraining to App Store
+    runs-on: macos-latest
+    if: github.event.pull_request.merged == true
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Cache SPM packages
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/Library/Developer/Xcode/DerivedData/**/SourcePackages
+            **/Package.resolved
+          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
+
+      - name: Create xcconfig files
+        env:
+          RELEASE_XCCONFIG: ${{ secrets.RELEASE_XCCONFIG }}
+        run: |
+          CONFIG_DIR="SoloDeveloperTraining/SoloDeveloperTraining/App/Config"
+          mkdir -p "$CONFIG_DIR"
+
+          if [ -z "$RELEASE_XCCONFIG" ]; then
+            echo "❌ RELEASE_XCCONFIG secret is missing."
+            exit 1
+          fi
+
+          printf "%s" "$RELEASE_XCCONFIG" > "$CONFIG_DIR/Release.xcconfig"
+
+      - name: Get current version
+        id: version
+        run: |
+          VERSION=$(xcodebuild \
+            -workspace SoloDeveloperTraining.xcworkspace \
+            -scheme SoloDeveloperTraining \
+            -showBuildSettings 2>/dev/null \
+            | grep '^\s*MARKETING_VERSION' \
+            | head -1 \
+            | awk '{print $3}')
+          echo "current=$VERSION" >> $GITHUB_OUTPUT
+          echo "Current version: $VERSION"
+
+      - name: Install certificate
+        env:
+          CERTIFICATE_BASE64: ${{ secrets.DISTRIBUTION_CERTIFICATE_BASE64 }}
+          CERTIFICATE_PASSWORD: ${{ secrets.DISTRIBUTION_CERTIFICATE_PASSWORD }}
+        run: |
+          echo "$CERTIFICATE_BASE64" | base64 --decode > certificate.p12
+          security create-keychain -p "" build.keychain
+          security set-keychain-settings -lut 21600 build.keychain
+          security unlock-keychain -p "" build.keychain
+          security import certificate.p12 -k build.keychain \
+            -P "$CERTIFICATE_PASSWORD" -T /usr/bin/codesign
+          security list-keychain -d user -s build.keychain login.keychain
+          security set-key-partition-list -S apple-tool:,apple: -s -k "" build.keychain
+
+      - name: Install provisioning profile
+        env:
+          PROFILE_BASE64: ${{ secrets.APP_PROVISIONING_PROFILE_BASE64 }}
+        run: |
+          mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
+          echo "$PROFILE_BASE64" | base64 --decode \
+            > ~/Library/MobileDevice/Provisioning\ Profiles/SoloDeveloperTraining.mobileprovision
+
+      - name: Install App Store Connect API key
+        env:
+          API_KEY_CONTENT: ${{ secrets.APP_STORE_CONNECT_API_KEY_CONTENT }}
+          API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+        run: |
+          mkdir -p ~/.appstoreconnect/private_keys
+          echo "$API_KEY_CONTENT" \
+            > ~/.appstoreconnect/private_keys/AuthKey_${API_KEY_ID}.p8
+
+      - name: Set provisioning profile in project
+        env:
+          PROFILE_NAME: ${{ secrets.APP_PROVISIONING_PROFILE_NAME }}
+        run: |
+          python3 - << 'PYEOF'
+          import re, os
+          pbxproj = "SoloDeveloperTraining/SoloDeveloperTraining.xcodeproj/project.pbxproj"
+          profile = os.environ["PROFILE_NAME"]
+          with open(pbxproj, "r") as f:
+              content = f.read()
+          # SoloDeveloperTraining Release config(08267F382F0D06BE005A0066)에만 적용
+          pattern = r'(08267F382F0D06BE005A0066 /\* Release \*/ = \{.*?PROVISIONING_PROFILE_SPECIFIER = )"[^"]*"(;\s*\n\s*"PROVISIONING_PROFILE_SPECIFIER\[sdk=iphoneos\*\]" = )[^;]*;'
+          content = re.sub(pattern, f'\\1"{profile}"\\2{profile};', content, flags=re.DOTALL)
+          with open(pbxproj, "w") as f:
+              f.write(content)
+          PYEOF
+
+      - name: Archive
+        run: |
+          xcodebuild archive \
+            -workspace SoloDeveloperTraining.xcworkspace \
+            -scheme SoloDeveloperTraining \
+            -configuration Release \
+            -archivePath build/SoloDeveloperTraining.xcarchive \
+            CURRENT_PROJECT_VERSION=${{ github.run_number }} \
+            DEVELOPMENT_TEAM=QBLK6726G4 \
+            CODE_SIGN_STYLE=Manual \
+            "CODE_SIGN_IDENTITY=Apple Distribution"
+
+      - name: Upload to App Store Connect
+        env:
+          API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          PROFILE_NAME: ${{ secrets.APP_PROVISIONING_PROFILE_NAME }}
+        run: |
+          cat > ExportOptions.plist << EOF
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+            <key>method</key>
+            <string>app-store-connect</string>
+            <key>destination</key>
+            <string>upload</string>
+            <key>signingStyle</key>
+            <string>manual</string>
+            <key>provisioningProfiles</key>
+            <dict>
+              <key>kr.codesquad.boostcamp10.SoloDeveloperTraining</key>
+              <string>${PROFILE_NAME}</string>
+            </dict>
+          </dict>
+          </plist>
+          EOF
+
+          xcodebuild -exportArchive \
+            -archivePath build/SoloDeveloperTraining.xcarchive \
+            -exportOptionsPlist ExportOptions.plist \
+            -exportPath build/export \
+            -authenticationKeyPath ~/.appstoreconnect/private_keys/AuthKey_${API_KEY_ID}.p8 \
+            -authenticationKeyID "$API_KEY_ID" \
+            -authenticationKeyIssuerID "$API_ISSUER_ID"
+
+      - name: Tag released version
+        run: |
+          VERSION="${{ steps.version.outputs.current }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "app/$VERSION"
+          git push origin "app/$VERSION"

--- a/.github/workflows/app-testflight-cd.yml
+++ b/.github/workflows/app-testflight-cd.yml
@@ -2,7 +2,9 @@ name: App TestFlight CD
 
 on:
   push:
-    branches: ['release/**', 'hotfix/**']
+    branches:
+      - 'release/[0-9]*.[0-9]*.[0-9]*'
+      - 'hotfix/[0-9]*.[0-9]*.[0-9]*'
   create:
 
 jobs:

--- a/.github/workflows/app-testflight-cd.yml
+++ b/.github/workflows/app-testflight-cd.yml
@@ -1,0 +1,158 @@
+name: App TestFlight CD
+
+on:
+  push:
+    branches: ['release/**', 'hotfix/**']
+  create:
+
+jobs:
+  deploy:
+    name: Deploy SoloDeveloperTraining to TestFlight
+    runs-on: macos-latest
+    if: |
+      (github.event_name == 'push' && (startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/heads/hotfix/'))) ||
+      (github.event_name == 'create' && github.ref_type == 'branch' && (startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/heads/hotfix/')))
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Cache SPM packages
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/Library/Developer/Xcode/DerivedData/**/SourcePackages
+            **/Package.resolved
+          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
+
+      - name: Create xcconfig files
+        env:
+          RELEASE_XCCONFIG: ${{ secrets.RELEASE_XCCONFIG }}
+        run: |
+          CONFIG_DIR="SoloDeveloperTraining/SoloDeveloperTraining/App/Config"
+          mkdir -p "$CONFIG_DIR"
+
+          if [ -z "$RELEASE_XCCONFIG" ]; then
+            echo "❌ RELEASE_XCCONFIG secret is missing."
+            exit 1
+          fi
+
+          printf "%s" "$RELEASE_XCCONFIG" > "$CONFIG_DIR/Release.xcconfig"
+
+      - name: Get current version
+        id: version
+        run: |
+          VERSION=$(xcodebuild \
+            -workspace SoloDeveloperTraining.xcworkspace \
+            -scheme SoloDeveloperTraining \
+            -showBuildSettings 2>/dev/null \
+            | grep '^\s*MARKETING_VERSION' \
+            | head -1 \
+            | awk '{print $3}')
+          echo "current=$VERSION" >> $GITHUB_OUTPUT
+          echo "Current version: $VERSION"
+
+      - name: Install certificate
+        env:
+          CERTIFICATE_BASE64: ${{ secrets.DISTRIBUTION_CERTIFICATE_BASE64 }}
+          CERTIFICATE_PASSWORD: ${{ secrets.DISTRIBUTION_CERTIFICATE_PASSWORD }}
+        run: |
+          echo "$CERTIFICATE_BASE64" | base64 --decode > certificate.p12
+          security create-keychain -p "" build.keychain
+          security set-keychain-settings -lut 21600 build.keychain
+          security unlock-keychain -p "" build.keychain
+          security import certificate.p12 -k build.keychain \
+            -P "$CERTIFICATE_PASSWORD" -T /usr/bin/codesign
+          security list-keychain -d user -s build.keychain login.keychain
+          security set-key-partition-list -S apple-tool:,apple: -s -k "" build.keychain
+
+      - name: Install provisioning profile
+        env:
+          PROFILE_BASE64: ${{ secrets.APP_PROVISIONING_PROFILE_BASE64 }}
+        run: |
+          mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
+          echo "$PROFILE_BASE64" | base64 --decode \
+            > ~/Library/MobileDevice/Provisioning\ Profiles/SoloDeveloperTraining.mobileprovision
+
+      - name: Install App Store Connect API key
+        env:
+          API_KEY_CONTENT: ${{ secrets.APP_STORE_CONNECT_API_KEY_CONTENT }}
+          API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+        run: |
+          mkdir -p ~/.appstoreconnect/private_keys
+          echo "$API_KEY_CONTENT" \
+            > ~/.appstoreconnect/private_keys/AuthKey_${API_KEY_ID}.p8
+
+      - name: Set provisioning profile in project
+        env:
+          PROFILE_NAME: ${{ secrets.APP_PROVISIONING_PROFILE_NAME }}
+        run: |
+          python3 - << 'PYEOF'
+          import re, os
+          pbxproj = "SoloDeveloperTraining/SoloDeveloperTraining.xcodeproj/project.pbxproj"
+          profile = os.environ["PROFILE_NAME"]
+          with open(pbxproj, "r") as f:
+              content = f.read()
+          # SoloDeveloperTraining Release config(08267F382F0D06BE005A0066)에만 적용
+          pattern = r'(08267F382F0D06BE005A0066 /\* Release \*/ = \{.*?PROVISIONING_PROFILE_SPECIFIER = )"[^"]*"(;\s*\n\s*"PROVISIONING_PROFILE_SPECIFIER\[sdk=iphoneos\*\]" = )[^;]*;'
+          content = re.sub(pattern, f'\\1"{profile}"\\2{profile};', content, flags=re.DOTALL)
+          with open(pbxproj, "w") as f:
+              f.write(content)
+          PYEOF
+
+      - name: Archive
+        run: |
+          xcodebuild archive \
+            -workspace SoloDeveloperTraining.xcworkspace \
+            -scheme SoloDeveloperTraining \
+            -configuration Release \
+            -archivePath build/SoloDeveloperTraining.xcarchive \
+            CURRENT_PROJECT_VERSION=${{ github.run_number }} \
+            DEVELOPMENT_TEAM=QBLK6726G4 \
+            CODE_SIGN_STYLE=Manual \
+            "CODE_SIGN_IDENTITY=Apple Distribution"
+
+      - name: Upload to TestFlight
+        env:
+          API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          PROFILE_NAME: ${{ secrets.APP_PROVISIONING_PROFILE_NAME }}
+        run: |
+          cat > ExportOptions.plist << EOF
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+            <key>method</key>
+            <string>app-store-connect</string>
+            <key>destination</key>
+            <string>upload</string>
+            <key>signingStyle</key>
+            <string>manual</string>
+            <key>provisioningProfiles</key>
+            <dict>
+              <key>kr.codesquad.boostcamp10.SoloDeveloperTraining</key>
+              <string>${PROFILE_NAME}</string>
+            </dict>
+          </dict>
+          </plist>
+          EOF
+
+          xcodebuild -exportArchive \
+            -archivePath build/SoloDeveloperTraining.xcarchive \
+            -exportOptionsPlist ExportOptions.plist \
+            -exportPath build/export \
+            -authenticationKeyPath ~/.appstoreconnect/private_keys/AuthKey_${API_KEY_ID}.p8 \
+            -authenticationKeyID "$API_KEY_ID" \
+            -authenticationKeyIssuerID "$API_ISSUER_ID"

--- a/.github/workflows/release-hotfix-to-dev-pr.yml
+++ b/.github/workflows/release-hotfix-to-dev-pr.yml
@@ -1,4 +1,4 @@
-name: Auto PR release → dev
+name: Auto PR release/hotfix → dev
 
 on:
   pull_request:
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   create-dev-pr:
-    if: startsWith(github.event.pull_request.head.ref, 'release/')
+    if: startsWith(github.event.pull_request.head.ref, 'release/') || startsWith(github.event.pull_request.head.ref, 'hotfix/')
     runs-on: ubuntu-latest
     steps:
       - name: Create PR to dev

--- a/.github/workflows/release-to-dev-pr.yml
+++ b/.github/workflows/release-to-dev-pr.yml
@@ -1,0 +1,35 @@
+name: Auto PR release → dev
+
+on:
+  pull_request:
+    types: [opened]
+    branches:
+      - main
+
+permissions:
+  pull-requests: write
+
+jobs:
+  create-dev-pr:
+    if: startsWith(github.event.pull_request.head.ref, 'release/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create PR to dev
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const sourceBranch = context.payload.pull_request.head.ref;
+            const originalBody = context.payload.pull_request.body ?? '';
+            const originalTitle = context.payload.pull_request.title;
+            const originalNumber = context.payload.pull_request.number;
+
+            const body = `> 이 PR은 #${originalNumber} (${sourceBranch} → main)이 열릴 때 자동 생성되었습니다.\n\n${originalBody}`;
+
+            await github.rest.pulls.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `[auto] ${originalTitle} (→ dev)`,
+              head: sourceBranch,
+              base: 'dev',
+              body: body,
+            });

--- a/SoloDeveloperTraining/SoloDeveloperTraining.xcodeproj/project.pbxproj
+++ b/SoloDeveloperTraining/SoloDeveloperTraining.xcodeproj/project.pbxproj
@@ -783,7 +783,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.1;
+				MARKETING_VERSION = 1.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.devup.DUDesignSystem;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -823,7 +823,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.1;
+				MARKETING_VERSION = 1.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.devup.DUDesignSystem;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/SoloDeveloperTraining/SoloDeveloperTraining.xcodeproj/xcshareddata/xcschemes/SoloDeveloperTraining.xcscheme
+++ b/SoloDeveloperTraining/SoloDeveloperTraining.xcodeproj/xcshareddata/xcschemes/SoloDeveloperTraining.xcscheme
@@ -92,6 +92,6 @@
    </AnalyzeAction>
    <ArchiveAction
       buildConfiguration = "Release"
-      revealArchiveInOrganizer = "YES">
+      revealArchiveInOrganizer = "NO">
    </ArchiveAction>
 </Scheme>


### PR DESCRIPTION
## 연관된 이슈

- [KAN-97](https://devvup.atlassian.net/browse/KAN-97)

## 작업 내용 및 고민 내용

### 브랜치 전략

<img width="1559" height="674" alt="image" src="https://github.com/user-attachments/assets/8aeff550-e636-4a6a-ad75-70dbfdf3eb56" />

#### 전략 설명

- `dev`
  - 평소 기능 개발(`feature/...`)이 쌓이는 브랜치
  - 다음 버전 작업을 시작할 때 마케팅 버전을 미리 세팅합니다 (예: `1.1.2` → `2.0.0`)
- `release/x.y.z`
  - `dev`에서 분기해 QA를 진행하는 브랜치
  - 새 기능은 더 받지 않고, 버그 발견 시 `release/x.y.z/fix-N` 브랜치를 만들어 수정한 뒤
  `release/x.y.z`로 PR을 올려 머지합니다
  - QA가 끝나면 `main`과 `dev` 양쪽에 머지하고 브랜치는 삭제합니다
- `hotfix/x.y.z`
  - 이미 배포된 `main`에서 직접 분기하는 긴급 수정용 브랜치
  - `release`와 달리 자식 브랜치 없이 그 안에서 바로 커밋을 쌓고, 끝나면 `main`과 `dev`에 머지합니다
  (그 시점에 `release` 브랜치가 살아있다면 거기에도 반영)
- `main`
  - 실제 배포된 코드만 존재
  - `release`/`hotfix` 브랜치에서 main으로 머지되는 순간이 정식 배포 트리거입니다

#### 주요 포인트

- 마케팅 버전(`MARKETING_VERSION`)을 바꾸는 시점은 `dev`와 `hotfix` 두 곳뿐입니다
  - `dev`: 다음 버전 작업을 시작할 때 미리 세팅 -> 이후 `release`로 분기해도 이 값을 그대로 가져갑니다
  - `hotfix/x.y.z`: 분기 직후 패치 버전으로 새로 올립니다 (예: `2.0.0` → `2.0.1`)
  - `release/x.y.z`는 버전을 새로 건드리지 않습니다
  (만약 dev 브랜치에서 세팅하지 않았다면 버전 변경을 해도 괜찮습니다)
- 빌드 넘버(`CURRENT_PROJECT_VERSION`)는 사람이 신경 쓸 필요가 없습니다 -> CD가 매번 자동으로 채웁니다
  - 같은 마케팅 버전이라도 빌드 넘버만 다르면 TestFlight/App Store Connect는 별개 빌드로 인식합니다
- `release`와 `hotfix` 브랜치는 꼭 `main`과 `dev` 두 브랜치에 PR을 올려야합니다.
  -  직접 push로 우회하지 않고 PR을 거쳐야합니다
- (git flow 전략을 기반으로 하였습니다)

---

### 기존 워크플로우


| | 트리거 | 역할 |
|---|---|---|
| ios-ci.yml | push/pull_request → main, dev | 빌드 + 테스트 (CI) |
| designsystem-cd.yml | push → dev(마케팅 버전 변경 시에만) | DUDesignSystemExample TestFlight 배포 |
| release-note.yml | pull_request: closed (merged) → main | 릴리즈 노트 생성 |

---

### 추가되는 워크플로우

**`app-testflight-cd.yml`**
- 트리거: release/x.y.z, hotfix/x.y.z 브랜치가 원격에 생성되거나 push될 때
- 역할: QA 및 배포전 검토용. push될 때마다 무조건 archive & TestFlight 업로드, 빌드 넘버는 자동 증가

**`app-appstore-cd.yml`**
- 트리거: release/x.y.z 또는 hotfix/x.y.z → `main` PR이 머지될 때
- 역할: 정식 배포용 App Store Connect 업로드. 완료 후 `app/{version}` git 태그로 배포 이력 기록. 실제 App Store 심사 제출은 사람이 직접 진행

**`release-hotfix-to-dev-pr.yml`**
- 트리거: release/** 또는 hotfix/** → main PR이 열릴 때
- 역할: release/** 또는 hotfix/** → dev PR을 자동 생성. 원본 PR 제목/본문을 그대로 복사하며 제목 앞에 [auto] 표기

## 기타 변경

- `SoloDeveloperTraining.xcscheme`의 `revealArchiveInOrganizer`를 `YES` → `NO`로 변경. CI(헤드리스 환경)에서 archive 후 Xcode Organizer가 자동으로 열리려는 동작을 막기 위함 — 디자인 시스템 CD 구축 시([#324](https://github.com/boostcampwm2025/iOS01-Hmm/pull/324)) 겪었던 문제를 본 앱에 선반영

## 검증 필요

- 브랜치 전략에 대한 피드백 부탁드립니다...!
- 스크립트 파일에 이상함이 있는지 확인 부탁드립니다...!
- 본 PR이 `dev`에 머지된 이후, 실제 `release/x.y.z` 테스트 브랜치를 만들어 `app-testflight-cd.yml`이 정상 동작하는지 확인 필요합니다.
- `app-appstore-cd.yml`은 `main` PR 머지가 필요해 사전 검증이 제한적입니다.
  - 첫 실제 출시 시점에 함께 검증해야할지, 다른 방법이 있을지 고민중입니다.