### PR TITLE
app_opened 이벤트 로깅을 추가합니다.

### DIFF
--- a/SoloDeveloperTraining/SoloDeveloperTraining/App/SoloDeveloperTrainingApp.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/App/SoloDeveloperTrainingApp.swift
@@ -131,7 +131,19 @@ private extension SoloDeveloperTrainingApp {
             loadUser()
         }
         .onChange(of: scenePhase) { _, newPhase in
-            if newPhase == .background || newPhase == .inactive {
+            if newPhase == .active {
+                SessionManager.shared.handleForeground()
+                if SessionManager.shared.didStartNewSession, let user {
+                    AnalyticsService.shared.logAppOpened(
+                        nickname: user.nickname,
+                        entrySource: "direct",
+                        referrerShareID: "",
+                        isDeferredDeeplink: false
+                    )
+                    SessionManager.shared.consumeNewSession()
+                }
+            } else if newPhase == .background || newPhase == .inactive {
+                SessionManager.shared.handleBackground()
                 saveUser()
             }
         }

--- a/SoloDeveloperTraining/SoloDeveloperTraining/App/SoloDeveloperTrainingApp.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/App/SoloDeveloperTrainingApp.swift
@@ -171,6 +171,15 @@ private extension SoloDeveloperTrainingApp {
                     await MainActor.run {
                         self.user = user
                         checkFirstOpen(user: user)
+                        if SessionManager.shared.didStartNewSession {
+                            AnalyticsService.shared.logAppOpened(
+                                nickname: user.nickname,
+                                entrySource: "direct",
+                                referrerShareID: "",
+                                isDeferredDeeplink: false
+                            )
+                            SessionManager.shared.consumeNewSession()
+                        }
                     }
                 case .legacy(let career):
                     await MainActor.run {

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AnalyticsService.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/AnalyticsService.swift
@@ -19,6 +19,8 @@ final class AnalyticsService {
     /// 공유하기 중복 로깅 방지
     private var loggedShareCompletions: Set<String> = []
     private var loggedAppOpenedFromDeeplinkSessions: Set<String> = []
+    /// app_opened session_id 기준 중복 방지
+    private var loggedAppOpenedSessions: Set<String> = []
 
     private init() {}
 
@@ -36,25 +38,26 @@ final class AnalyticsService {
         ])
     }
 
-    /// 매 실행마다 카운트
+    /// 포그라운드 진입마다 1회 (session_id 기준 중복 방지)
     func logAppOpened(
         nickname: String,
-        level: Int,
         entrySource: String,
         referrerShareID: String,
         isDeferredDeeplink: Bool
     ) {
+        let sessionID = SessionManager.shared.sessionID
+        guard loggedAppOpenedSessions.insert(sessionID).inserted else { return }
+
         Analytics.logEvent("app_opened", parameters: [
             AP.deviceID: AP.deviceIDValue,
-            AP.sessionID: SessionManager.shared.sessionID,
+            AP.sessionID: sessionID,
             AP.nickname: nickname,
             AP.appVersion: AP.appVersionValue,
             AP.osVersion: AP.osVersionValue,
             AP.deviceModel: AP.deviceModelValue,
             AP.entrySource: entrySource,
             AP.referrerShareID: referrerShareID,
-            AP.isDeferredDeeplink: isDeferredDeeplink,
-            AP.level: level
+            AP.isDeferredDeeplink: isDeferredDeeplink
         ])
     }
 

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/SessionManager.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Analytics/SessionManager.swift
@@ -16,6 +16,9 @@ final class SessionManager {
     private var sessionStartTime: Date = Date()
     private var backgroundedAt: Date?
 
+    /// foreground 복귀 후 아직 로깅하지 않은 새 세션이 있으면 true
+    private(set) var didStartNewSession: Bool = true
+
     private static let sessionTimeoutSeconds: TimeInterval = 60
 
     // MARK: - App Lifecycle
@@ -24,12 +27,18 @@ final class SessionManager {
         if let backgroundedAt, Date().timeIntervalSince(backgroundedAt) > SessionManager.sessionTimeoutSeconds {
             sessionID = SessionManager.generateSessionID()
             sessionStartTime = Date()
+            didStartNewSession = true
         }
         self.backgroundedAt = nil
     }
 
     func handleBackground() {
         backgroundedAt = Date()
+    }
+
+    /// 새 세션 로깅 완료 후 플래그 소비
+    func consumeNewSession() {
+        didStartNewSession = false
     }
 
     // MARK: - Session Duration


### PR DESCRIPTION
## 연관된 이슈

- [#KAN-176](https://devvup.atlassian.net/jira/software/projects/KAN/boards/1/backlog?selectedIssue=KAN-176)

## 작업 내용

### app_opened 이벤트 로깅 추가

앱이 포그라운드로 진입할 때 `app_opened` 이벤트를 Firebase Analytics에 로깅합니다.

#### 트리거 조건

- `ScenePhase`가 `.active`로 전환될 때
- 세션 타임아웃(60초) 이후 복귀하여 새 `session_id`가 발급된 경우에만 1회 로깅 (session_id 기준 중복 방지)

#### 로깅 프로퍼티

| 프로퍼티 | 값 |
|---|---|
| `device_id` | `AnalyticsProperty.deviceIDValue` |
| `session_id` | `SessionManager.shared.sessionID` |
| `nickname` | 로그인된 유저 닉네임 |
| `entry_source` | `"direct"` |
| `referrer_share_id` | `""` (딥링크 유입 시 별도 이벤트로 처리) |
| `is_deferred_deeplink` | `false` |
| `app_version` | `CFBundleShortVersionString` |
| `os_version` | `UIDevice.current.systemVersion` |
| `device_model` | `UIDevice.current.model` |

#### 변경 파일

**`SessionManager.swift`**
- `didStartNewSession: Bool` 플래그 추가 — 포그라운드 복귀 시 새 세션이 발급되면 `true`로 갱신
- `consumeNewSession()` 추가 — 로깅 완료 후 플래그 소비
- `handleForeground()` / `handleBackground()` 를 `SoloDeveloperTrainingApp`에서 호출하도록 연결

**`AnalyticsService.swift`**
- `logAppOpened()` 시그니처에서 `level` 파라미터 제거 (비즈니스 요건 변경)
- `loggedAppOpenedSessions: Set<String>` 추가 — session_id 기준 중복 로깅 방지

**`SoloDeveloperTrainingApp.swift`**
- `onChange(of: scenePhase)` 분기 추가:
  - `.active` → `handleForeground()` → 신규 세션이면 `logAppOpened()` → `consumeNewSession()`
  - `.background` / `.inactive` → `handleBackground()` + `saveUser()`
