### PR TITLE
수출 규정 자동화를 적용합니다.

### DIFF
--- a/SoloDeveloperTraining/SoloDeveloperTraining.xcodeproj/project.pbxproj
+++ b/SoloDeveloperTraining/SoloDeveloperTraining.xcodeproj/project.pbxproj
@@ -772,6 +772,7 @@
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = QBLK6726G4;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -812,6 +813,7 @@
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = QBLK6726G4;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/SoloDeveloperTraining/SoloDeveloperTraining/App/Info.plist
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/App/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>ADMOB_INTERSTITIAL_AD_UNIT_ID</key>
 	<string>$(ADMOB_INTERSTITIAL_AD_UNIT_ID)</string>
 	<key>APPSFLYER_DEV_KEY</key>


### PR DESCRIPTION
## 작업 내용

새 버전 업로드마다 App Store Connect에서 수출 규정 문서를 수동으로 설정해야해서 자동 배포에 불편함이 있었습니다.  
`SoloDeveloperTraining`, `DUDesignSystemExample` 타겟의 Info에 다음을 추가하여 해결합니다.
- Key: App Uses Non-Exempt Encryption
- Value: NO
- Type: Boolean

[참고 링크](https://developer.apple.com/documentation/security/complying-with-encryption-export-regulations)

