### PR TITLE
PopupManager 도입 과정 중 GA 누락 이벤트를 추가합니다.

### DIFF
--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Work/Game/DodgeGameView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Work/Game/DodgeGameView.swift
@@ -43,6 +43,7 @@ struct DodgeGameView: View {
     @State private var isGameInitialized: Bool = false
     /// 골드 변화를 표시하는 효과 라벨 목록
     @State private var effectLabels: [EffectLabelData] = []
+    @State private var drinkAdRewardFlowID: String?
 
     /// 게임 시작 여부 (false로 바꾸면 선택 화면으로 복귀)
     @Binding var isGameStarted: Bool
@@ -269,6 +270,15 @@ private extension DodgeGameView {
         } else {
             game.pauseGame()
             isGamePaused = true
+            let flowID = AnalyticsService.shared.makeAdRewardFlowID()
+            drinkAdRewardFlowID = flowID
+            let rewardType: AdRewardType = type == .coffee ? .coffee : .energyDrink
+            AnalyticsService.shared.logAdOfferViewed(
+                adRewardFlowID: flowID,
+                adPlacement: .consumable(screenID: "caffein"),
+                rewardType: rewardType,
+                rewardAmount: 1
+            )
             PopupManager.shared.show {
                 NoticePopup(
                     type: .ad(
@@ -277,6 +287,16 @@ private extension DodgeGameView {
                         cancelAction: {
                             SoundService.shared.trigger(.click)
                             PopupManager.shared.dismiss()
+                            if let flowID = drinkAdRewardFlowID {
+                                AnalyticsService.shared.logAdOfferDismissed(
+                                    adRewardFlowID: flowID,
+                                    adPlacement: .consumable(screenID: "caffein"),
+                                    rewardType: rewardType,
+                                    rewardAmount: 1,
+                                    dismissReason: .close
+                                )
+                                drinkAdRewardFlowID = nil
+                            }
                             game.resumeGame()
                             isGamePaused = false
                         },
@@ -295,7 +315,8 @@ private extension DodgeGameView {
     func handleDrinkAd(type: ConsumableType) async {
         PopupManager.shared.dismiss()
 
-        let flowID = AnalyticsService.shared.makeAdRewardFlowID()
+        guard let flowID = drinkAdRewardFlowID else { return }
+        drinkAdRewardFlowID = nil
         let rewardType: AdRewardType = type == .coffee ? .coffee : .energyDrink
 
         AnalyticsService.shared.logAdWatchClicked(

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Work/Game/LanguageGameView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Work/Game/LanguageGameView.swift
@@ -27,6 +27,7 @@ struct LanguageGameView: View {
     @State private var currentActionTask: Task<Void, Never>?
     /// 획득한 골드를 표시하는 효과 라벨 목록
     @State private var effectLabels: [EffectLabelData] = []
+    @State private var drinkAdRewardFlowID: String?
 
     /// 게임 시작 여부 (false로 바꾸면 선택 화면으로 복귀)
     @Binding var isGameStarted: Bool
@@ -270,6 +271,15 @@ private extension LanguageGameView {
             }
         } else {
             game.pauseGame()
+            let flowID = AnalyticsService.shared.makeAdRewardFlowID()
+            drinkAdRewardFlowID = flowID
+            let rewardType: AdRewardType = type == .coffee ? .coffee : .energyDrink
+            AnalyticsService.shared.logAdOfferViewed(
+                adRewardFlowID: flowID,
+                adPlacement: .consumable(screenID: "caffein"),
+                rewardType: rewardType,
+                rewardAmount: 1
+            )
             PopupManager.shared.show {
                 NoticePopup(
                     type: .ad(
@@ -278,6 +288,16 @@ private extension LanguageGameView {
                         cancelAction: {
                             SoundService.shared.trigger(.click)
                             PopupManager.shared.dismiss()
+                            if let flowID = drinkAdRewardFlowID {
+                                AnalyticsService.shared.logAdOfferDismissed(
+                                    adRewardFlowID: flowID,
+                                    adPlacement: .consumable(screenID: "caffein"),
+                                    rewardType: rewardType,
+                                    rewardAmount: 1,
+                                    dismissReason: .close
+                                )
+                                drinkAdRewardFlowID = nil
+                            }
                             game.resumeGame()
                         },
                         adAction: {
@@ -295,7 +315,8 @@ private extension LanguageGameView {
     func handleDrinkAd(type: ConsumableType) async {
         PopupManager.shared.dismiss()
 
-        let flowID = AnalyticsService.shared.makeAdRewardFlowID()
+        guard let flowID = drinkAdRewardFlowID else { return }
+        drinkAdRewardFlowID = nil
         let rewardType: AdRewardType = type == .coffee ? .coffee : .energyDrink
 
         AnalyticsService.shared.logAdWatchClicked(

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Work/Game/StackGameView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Work/Game/StackGameView.swift
@@ -27,6 +27,7 @@ struct StackGameView: View {
     @State private var scene: StackGameScene
     /// 획득한 골드를 표시하는 효과 라벨 목록
     @State private var effectLabels: [EffectLabelData] = []
+    @State private var drinkAdRewardFlowID: String?
 
     /// 게임 시작 여부 (false로 바꾸면 선택 화면으로 복귀)
     @Binding var isGameStarted: Bool
@@ -191,6 +192,15 @@ private extension StackGameView {
             }
         } else {
             scene.pauseGame()
+            let flowID = AnalyticsService.shared.makeAdRewardFlowID()
+            drinkAdRewardFlowID = flowID
+            let rewardType: AdRewardType = type == .coffee ? .coffee : .energyDrink
+            AnalyticsService.shared.logAdOfferViewed(
+                adRewardFlowID: flowID,
+                adPlacement: .consumable(screenID: "caffein"),
+                rewardType: rewardType,
+                rewardAmount: 1
+            )
             PopupManager.shared.show {
                 NoticePopup(
                     type: .ad(
@@ -199,6 +209,16 @@ private extension StackGameView {
                         cancelAction: {
                             SoundService.shared.trigger(.click)
                             PopupManager.shared.dismiss()
+                            if let flowID = drinkAdRewardFlowID {
+                                AnalyticsService.shared.logAdOfferDismissed(
+                                    adRewardFlowID: flowID,
+                                    adPlacement: .consumable(screenID: "caffein"),
+                                    rewardType: rewardType,
+                                    rewardAmount: 1,
+                                    dismissReason: .close
+                                )
+                                drinkAdRewardFlowID = nil
+                            }
                             scene.resumeGame()
                         },
                         adAction: {
@@ -216,7 +236,8 @@ private extension StackGameView {
     func handleDrinkAd(type: ConsumableType) async {
         PopupManager.shared.dismiss()
 
-        let flowID = AnalyticsService.shared.makeAdRewardFlowID()
+        guard let flowID = drinkAdRewardFlowID else { return }
+        drinkAdRewardFlowID = nil
         let rewardType: AdRewardType = type == .coffee ? .coffee : .energyDrink
 
         AnalyticsService.shared.logAdWatchClicked(

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Work/Game/TapGameView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Work/Game/TapGameView.swift
@@ -24,6 +24,7 @@ struct TapGameView: View {
     @State private var effectLabels: [EffectLabelData] = []
     /// 탭 사운드 쓰로틀용 마지막 재생 시각
     @State private var lastTapSoundTime: Date = .distantPast
+    @State private var drinkAdRewardFlowID: String?
 
     /// 게임 시작 여부 (false로 바꾸면 선택 화면으로 복귀)
     @Binding var isGameStarted: Bool
@@ -193,6 +194,15 @@ private extension TapGameView {
             }
         } else {
             tapGame.pauseGame()
+            let flowID = AnalyticsService.shared.makeAdRewardFlowID()
+            drinkAdRewardFlowID = flowID
+            let rewardType: AdRewardType = type == .coffee ? .coffee : .energyDrink
+            AnalyticsService.shared.logAdOfferViewed(
+                adRewardFlowID: flowID,
+                adPlacement: .consumable(screenID: "caffein"),
+                rewardType: rewardType,
+                rewardAmount: 1
+            )
             PopupManager.shared.show {
                 NoticePopup(
                     type: .ad(
@@ -201,6 +211,16 @@ private extension TapGameView {
                         cancelAction: {
                             SoundService.shared.trigger(.click)
                             PopupManager.shared.dismiss()
+                            if let flowID = drinkAdRewardFlowID {
+                                AnalyticsService.shared.logAdOfferDismissed(
+                                    adRewardFlowID: flowID,
+                                    adPlacement: .consumable(screenID: "caffein"),
+                                    rewardType: rewardType,
+                                    rewardAmount: 1,
+                                    dismissReason: .close
+                                )
+                                drinkAdRewardFlowID = nil
+                            }
                             tapGame.resumeGame()
                         },
                         adAction: {
@@ -218,7 +238,8 @@ private extension TapGameView {
     func handleDrinkAd(type: ConsumableType) async {
         PopupManager.shared.dismiss()
 
-        let flowID = AnalyticsService.shared.makeAdRewardFlowID()
+        guard let flowID = drinkAdRewardFlowID else { return }
+        drinkAdRewardFlowID = nil
         let rewardType: AdRewardType = type == .coffee ? .coffee : .energyDrink
 
         AnalyticsService.shared.logAdWatchClicked(
@@ -238,7 +259,7 @@ private extension TapGameView {
                 rewardAmount: 1,
                 adWatchDurationSec: result.watchDurationSec
             )
-            tapGame.user.inventory.gain(consumable: type)
+            tapGame.inventory.gain(consumable: type)
             ToastManager.shared.show("카페인 충전 완료!")
             AnalyticsService.shared.logAdRewardClaimed(
                 adRewardFlowID: flowID,


### PR DESCRIPTION
## 연관된 이슈

- [Popup Manager 도입 PR](https://github.com/boostcampwm2025/iOS01-Hmm/pull/359)
- [광고 이벤트 연결 작업 PR](https://github.com/boostcampwm2025/iOS01-Hmm/pull/341)

## 작업 내용 및 고민 내용

<img width="970" height="421" alt="image" src="https://github.com/user-attachments/assets/5e434999-188c-4346-8ce2-317ff42c0515" />

MainView에서 각 GameView로 Popup 생성 역할이 넘어가면서,  
누락되었던 2개의 이벤트(팝업이 분리되면서 8개(2개 * 4개 View))를 추가했습니다 🥹