### PR TITLE
fix: create 이벤트 트리거 제거

### DIFF
--- a/.github/workflows/app-testflight-cd.yml
+++ b/.github/workflows/app-testflight-cd.yml
@@ -5,15 +5,12 @@ on:
     branches:
       - 'release/[0-9]*.[0-9]*.[0-9]*'
       - 'hotfix/[0-9]*.[0-9]*.[0-9]*'
-  create:
 
 jobs:
   deploy:
     name: Deploy SoloDeveloperTraining to TestFlight
     runs-on: macos-latest
-    if: |
-      (github.event_name == 'push' && (startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/heads/hotfix/'))) ||
-      (github.event_name == 'create' && github.ref_type == 'branch' && (startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/heads/hotfix/')))
+
     permissions:
       contents: read
 


### PR DESCRIPTION
## 확인해주세요
- 깃허브 웹에서 `release/2.0.0` 브랜치 직접 생성 후 기존 cd 코드를 동작시켰을 때, create 및 push 이벤트가 중복으로 동작하여 빌드가 2번 업로드 되는 문제를 확인했습니다.
- 브랜치를 생성 할 때 'dev'를 base로 생성하므로 'dev'에 있던 커밋들이 push 되면서 트리거를 발생시킨 것으로 확인했습니다.
- 따라서 create 이벤트는 제거하고, push 이벤트만 남겨두었습니다.