### PR TITLE
타이포그래피 행간, 팝업 클릭음 버그를 수정하고 시나리오 복구 우선순위를 설정합니다.

### DIFF
--- a/DUDesignSystem/Sources/DUDesignSystem/Components/Popups/StorePopup.swift
+++ b/DUDesignSystem/Sources/DUDesignSystem/Components/Popups/StorePopup.swift
@@ -104,7 +104,7 @@ public struct StorePopup: View {
                 confirmAction: {}
             ),
             title: "아이템구매",
-            itemName: "박하스",
+            itemName: "바카스",
             price: "[₩2,000,000]"
         )
         StorePopup(

--- a/DUDesignSystem/Sources/DUDesignSystem/Token/TokenTypography.swift
+++ b/DUDesignSystem/Sources/DUDesignSystem/Token/TokenTypography.swift
@@ -33,7 +33,7 @@ private enum FontRegistrar {
 
 private func makeToken(_ name: String, size: CGFloat, lineHeight: CGFloat, underlined: Bool = false) -> DUTypographyToken {
     _ = FontRegistrar.register
-    return DUTypographyToken(.custom(name, size: size), underlined: underlined, lineHeight: lineHeight)
+    return DUTypographyToken(.custom(name, size: size), underlined: underlined, fontSize: size, lineHeight: lineHeight)
 }
 
 // MARK: - 타이포그래피 토큰
@@ -43,11 +43,13 @@ private func makeToken(_ name: String, size: CGFloat, lineHeight: CGFloat, under
 public struct DUTypographyToken: Sendable, Hashable {
     public let font: Font
     public let isUnderlined: Bool
+    public let fontSize: CGFloat
     public let lineHeight: CGFloat
 
-    init(_ font: Font, underlined: Bool = false, lineHeight: CGFloat) {
+    init(_ font: Font, underlined: Bool = false, fontSize: CGFloat, lineHeight: CGFloat) {
         self.font = font
         self.isUnderlined = underlined
+        self.fontSize = fontSize
         self.lineHeight = lineHeight
     }
 
@@ -68,15 +70,18 @@ private struct DUFontModifier: ViewModifier {
     let token: DUTypographyToken
 
     func body(content: Content) -> some View {
+        let spacing = (token.lineHeight - token.fontSize) / 2
         if token.isUnderlined {
             content
                 .font(token.font)
+                .lineSpacing(spacing * 2)
                 .underline()
-                .frame(minHeight: token.lineHeight)
+                .padding(.vertical, spacing)
         } else {
             content
                 .font(token.font)
-                .frame(minHeight: token.lineHeight)
+                .lineSpacing(spacing * 2)
+                .padding(.vertical, spacing)
         }
     }
 }

--- a/SoloDeveloperTraining/SoloDeveloperTraining/App/SoloDeveloperTrainingApp.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/App/SoloDeveloperTrainingApp.swift
@@ -114,10 +114,11 @@ private extension SoloDeveloperTrainingApp {
             if type == .force {
                 PopupManager.shared.show {
                     NoticePopup(
-                        type: .default(
-                            buttonText: "업데이트",
-                            action: { AppUpdateChecker.openAppStore() }
-                        ),
+                        type: .default(buttonText: "업데이트",
+                                       action: {
+                                           SoundService.shared.trigger(.click)
+                                           AppUpdateChecker.openAppStore()
+                                       }),
                         title: "업데이트 안내",
                         text: "원활한 앱 사용을 위해서 업데이트가 필요합니다.\n지금 바로 업데이트를 진행해주세요."
                     )
@@ -130,10 +131,14 @@ private extension SoloDeveloperTrainingApp {
                             cancelText: "다음에",
                             confirmText: "업데이트",
                             cancelAction: {
+                                SoundService.shared.trigger(.click)
                                 AppUpdateChecker.snoozeOptionalUpdate()
                                 PopupManager.shared.dismiss()
                             },
-                            confirmAction: { AppUpdateChecker.openAppStore() }
+                            confirmAction: {
+                                SoundService.shared.trigger(.click)
+                                AppUpdateChecker.openAppStore()
+                            }
                         ),
                         title: "업데이트 안내",
                         text: "원활한 앱 사용을 위해서 업데이트가 필요합니다.\n지금 바로 업데이트를 진행해주세요."
@@ -213,7 +218,11 @@ private extension SoloDeveloperTrainingApp {
                 await MainActor.run {
                     PopupManager.shared.show {
                         NoticePopup(
-                            type: .default(buttonText: "확인", action: { PopupManager.shared.dismiss() }),
+                            type: .default(buttonText: "확인",
+                                           action: {
+                                               SoundService.shared.trigger(.click)
+                                               PopupManager.shared.dismiss()
+                                           }),
                             title: "오류",
                             text: "사용자 데이터를 불러오는데 실패했습니다.\n\(error.localizedDescription)"
                         )
@@ -235,7 +244,11 @@ private extension SoloDeveloperTrainingApp {
                 await MainActor.run {
                     PopupManager.shared.show {
                         NoticePopup(
-                            type: .default(buttonText: "확인", action: { PopupManager.shared.dismiss() }),
+                            type: .default(buttonText: "확인",
+                                           action: {
+                                               SoundService.shared.trigger(.click)
+                                               PopupManager.shared.dismiss()
+                                           }),
                             title: "오류",
                             text: "사용자 데이터를 저장하는데 실패했습니다.\n\(error.localizedDescription)"
                         )

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Devlopment/Presentation/MissionTestView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Devlopment/Presentation/MissionTestView.swift
@@ -401,7 +401,7 @@ struct MissionTestView: View {
                 Spacer()
 
                 VStack {
-                    Text("박하스")
+                    Text("바카스")
                         .font(.caption)
                     Text("\(record.energyDrinkUseCount)")
                         .font(.title3)
@@ -439,7 +439,7 @@ struct MissionTestView: View {
                 Button {
                     performEnergyDrinkUse()
                 } label: {
-                    Label("박하스 +1", systemImage: "bolt.circle.fill")
+                    Label("바카스 +1", systemImage: "bolt.circle.fill")
                         .frame(maxWidth: .infinity)
                         .padding()
                         .background(Color.mint)
@@ -450,7 +450,7 @@ struct MissionTestView: View {
                 Button {
                     performEnergyDrinkUse(count: 10)
                 } label: {
-                    Label("박하스 +10", systemImage: "bolt.fill")
+                    Label("바카스 +10", systemImage: "bolt.fill")
                         .frame(maxWidth: .infinity)
                         .padding()
                         .background(Color.mint.opacity(0.7))

--- a/SoloDeveloperTraining/SoloDeveloperTraining/GameCore/Models/Items/Consumable.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/GameCore/Models/Items/Consumable.swift
@@ -66,7 +66,7 @@ enum ConsumableType {
         case .coffee:
             return "커피"
         case .energyDrink:
-            return "박하스"
+            return "바카스"
         }
     }
 

--- a/SoloDeveloperTraining/SoloDeveloperTraining/GameCore/Models/Policy.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/GameCore/Models/Policy.swift
@@ -213,7 +213,7 @@ enum Policy {
             static var priceDiamond: Int { policyStore.current.consumable.coffee.priceDiamond }
         }
 
-        /// 박하스 (1초당 6씩 증가)
+        /// 바카스 (1초당 6씩 증가)
         enum EnergyDrink {
             static var duration: Int { policyStore.current.consumable.energyDrink.duration }
             static var buffMultiplier: Double { policyStore.current.consumable.energyDrink.buffMultiplier }

--- a/SoloDeveloperTraining/SoloDeveloperTraining/GameCore/Models/Systems/MissionConstants.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/GameCore/Models/Systems/MissionConstants.swift
@@ -87,14 +87,14 @@ enum MissionConstants {
         static let reward3 = Cost(gold: 50_000, diamond: 18)
     }
 
-    // MARK: - 박하스
+    // MARK: - 바카스
     enum EnergyDrink {
         static let id1 = 19, id2 = 20, id3 = 21
         static let target1 = 10, target2 = 100, target3 = 1_000
-        static let title1 = "박하스 중독자", title2 = "박하스 전문가", title3 = "박하스 학살자"
-        static let description1 = "박하스 10회 사용"
-        static let description2 = "박하스 100회 사용"
-        static let description3 = "박하스 1,000회 사용"
+        static let title1 = "바카스 중독자", title2 = "바카스 전문가", title3 = "바카스 학살자"
+        static let description1 = "바카스 10회 사용"
+        static let description2 = "바카스 100회 사용"
+        static let description3 = "바카스 1,000회 사용"
         static let reward1 = Cost(diamond: 7)
         static let reward2 = Cost(gold: 225_000)
         static let reward3 = Cost(gold: 2_250_000, diamond: 35)

--- a/SoloDeveloperTraining/SoloDeveloperTraining/GameCore/Models/Systems/MissionFactory.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/GameCore/Models/Systems/MissionFactory.swift
@@ -264,7 +264,7 @@ struct MissionFactory {
                 type: .coffee(.gold)
             ),
 
-            // MARK: - 박하스
+            // MARK: - 바카스
             MissionConfig(
                 id: MissionConstants.EnergyDrink.id1,
                 title: MissionConstants.EnergyDrink.title1,

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/FeedbackSystem/SoundType.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/FeedbackSystem/SoundType.swift
@@ -51,7 +51,7 @@ enum SoundType: String {
     case pop
 
     // MARK: - 04. 업무 - 공통
-    /// 아이템(커피/박하스) 소비 시
+    /// 아이템(커피/바카스) 소비 시
     case drink
 
     // MARK: - 05. 상점 - 아이템

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/MainView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/MainView.swift
@@ -320,10 +320,6 @@ private extension MainView {
                 }
             }
         }
-        // 저장된 시나리오 복구 체크
-        restoreScenarioIfNeeded()
-        // 대기 중인 레벨업 이펙트 복구 체크
-        checkPendingLevelUp()
     }
 
     @MainActor
@@ -587,6 +583,10 @@ private extension MainView {
             showOfflineRewardPopup()
         case .notEligible(_):
             hasCheckedOfflineReward = false
+            checkPendingLevelUp()
+            if !showLevelUpEffect {
+                restoreScenarioIfNeeded()
+            }
         }
     }
 
@@ -633,6 +633,10 @@ private extension MainView {
         }
         offlineRewardGold = 0
         offlineRewardHours = 0.0
+        checkPendingLevelUp()
+        if !showLevelUpEffect {
+            restoreScenarioIfNeeded()
+        }
     }
 
     func handleOfflineRewardSkip() {
@@ -651,6 +655,10 @@ private extension MainView {
         offlineRewardHours = 0.0
         // 다음 체크를 위해 플래그 리셋
         hasCheckedOfflineReward = false
+        checkPendingLevelUp()
+        if !showLevelUpEffect {
+            restoreScenarioIfNeeded()
+        }
     }
 }
 

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/ShopView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/ShopView.swift
@@ -307,7 +307,11 @@ private extension ShopView {
                 let message = isSuccess ? Constant.Text.enhanceSuccessMessage : Constant.Text.enhanceFailureMessage
                 PopupManager.shared.show {
                     NoticePopup(
-                        type: .default(buttonText: "확인", action: { PopupManager.shared.dismiss() }),
+                        type: .default(buttonText: "확인",
+                                       action: {
+                                           SoundService.shared.trigger(.click)
+                                           PopupManager.shared.dismiss()
+                                       }),
                         title: title,
                         text: message
                     )
@@ -317,7 +321,11 @@ private extension ShopView {
             HapticService.shared.trigger(.error)
             PopupManager.shared.show {
                 NoticePopup(
-                    type: .default(buttonText: "확인", action: { PopupManager.shared.dismiss() }),
+                    type: .default(buttonText: "확인",
+                                   action: {
+                                       SoundService.shared.trigger(.click)
+                                       PopupManager.shared.dismiss()
+                                   }),
                     title: Constant.Text.purchaseFailureTitle,
                     text: error.message
                 )
@@ -326,7 +334,11 @@ private extension ShopView {
             HapticService.shared.trigger(.error)
             PopupManager.shared.show {
                 NoticePopup(
-                    type: .default(buttonText: "확인", action: { PopupManager.shared.dismiss() }),
+                    type: .default(buttonText: "확인",
+                                   action: {
+                                       SoundService.shared.trigger(.click)
+                                       PopupManager.shared.dismiss()
+                                   }),
                     title: Constant.Text.purchaseFailureTitle,
                     text: Constant.Text.purchaseFailureMessage
                 )

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/SkillView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/SkillView.swift
@@ -92,7 +92,11 @@ private extension SkillView {
         } catch let error as UserReadableError {
             PopupManager.shared.show {
                 NoticePopup(
-                    type: .default(buttonText: "확인", action: { PopupManager.shared.dismiss() }),
+                    type: .default(buttonText: "확인",
+                                   action: {
+                                       SoundService.shared.trigger(.click)
+                                       PopupManager.shared.dismiss()
+                                   }),
                     title: "스킬",
                     text: error.message
                 )
@@ -100,7 +104,11 @@ private extension SkillView {
         } catch {
             PopupManager.shared.show {
                 NoticePopup(
-                    type: .default(buttonText: "확인", action: { PopupManager.shared.dismiss() }),
+                    type: .default(buttonText: "확인",
+                                   action: {
+                                       SoundService.shared.trigger(.click)
+                                       PopupManager.shared.dismiss()
+                                   }),
                     title: "스킬",
                     text: error.localizedDescription
                 )
@@ -143,6 +151,7 @@ private extension SkillView {
             PopupManager.shared.show {
                 NoticePopup(
                     type: .default(buttonText: "확인", action: {
+                        SoundService.shared.trigger(.click)
                         PopupManager.shared.dismiss()
                         SkillAdRewardManager.grantReward(user: user)
                         AnalyticsService.shared.logAdRewardClaimed(

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Work/Game/DodgeGameView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Work/Game/DodgeGameView.swift
@@ -304,7 +304,7 @@ private extension DodgeGameView {
                             Task { await handleDrinkAd(type: type) }
                         }
                     ),
-                    title: type == .coffee ? "커피 없음" : "박하스 없음",
+                    title: type == .coffee ? "커피 없음" : "바카스 없음",
                     text: "대신에 광고를 보고\n카페인을 보충할까요?"
                 )
                 .analyticsScreen(.caffein)

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Work/Game/LanguageGameView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Work/Game/LanguageGameView.swift
@@ -304,7 +304,7 @@ private extension LanguageGameView {
                             Task { await handleDrinkAd(type: type) }
                         }
                     ),
-                    title: type == .coffee ? "커피 없음" : "박하스 없음",
+                    title: type == .coffee ? "커피 없음" : "바카스 없음",
                     text: "대신에 광고를 보고\n카페인을 보충할까요?"
                 )
                 .analyticsScreen(.caffein)

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Work/Game/StackGameView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Work/Game/StackGameView.swift
@@ -225,7 +225,7 @@ private extension StackGameView {
                             Task { await handleDrinkAd(type: type) }
                         }
                     ),
-                    title: type == .coffee ? "커피 없음" : "박하스 없음",
+                    title: type == .coffee ? "커피 없음" : "바카스 없음",
                     text: "대신에 광고를 보고\n카페인을 보충할까요?"
                 )
                 .analyticsScreen(.caffein)

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Work/Game/TapGameView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Work/Game/TapGameView.swift
@@ -227,7 +227,7 @@ private extension TapGameView {
                             Task { await handleDrinkAd(type: type) }
                         }
                     ),
-                    title: type == .coffee ? "커피 없음" : "박하스 없음",
+                    title: type == .coffee ? "커피 없음" : "바카스 없음",
                     text: "대신에 광고를 보고\n카페인을 보충할까요?"
                 )
                 .analyticsScreen(.caffein)


### PR DESCRIPTION
## 연관된 이슈

- [KAN-196](https://devvup.atlassian.net/browse/KAN-196)
- [KAN-203](https://devvup.atlassian.net/browse/KAN-203)
- [KAN-216](https://devvup.atlassian.net/browse/KAN-216)

## 작업 내용 및 고민 내용

### 1. 네이밍 통일 (박하스 → 바카스)

Figma 디자인 기준에 맞게 아이템 이름을 바카스로 통일했습니다.

---

### 2. 두 줄 이상인 Text에 대해 타이포그래피 행간 적용

팝업 컴포넌트에서 텍스트가 줄바꿈될 때 행간이 없어 너무 붙어 보이는 문제를 발견했습니다.  
Figma 디자인 시스템의 line-height 토큰이 코드에 반영되지 않고 있었습니다.  
(Text가 한 줄인 경우는 적용되는 상태였지만, Text가 두 줄 이상인 경우에는 적용되지 않았다고 보입니다)

#### 변경 작업
- 작업 파일: `DUDesignSystem/Sources/DUDesignSystem/Token/TokenTypography.swift`
- 줄 사이 간격 반영: `.lineSpacing(token.lineHeight - token.fontSize)` 추가
- Text 위 아래 여백 반영: `.padding(.vertical, (token.lineHeight - token.fontSize) / 2)` 추가

| 변경 전 | 변경 후 |
|---|---|
| <img width="279" height="615" alt="image" src="https://github.com/user-attachments/assets/60429ca4-4057-480c-adf0-7e22012998ad" /> | <img width="276" height="596" alt="image" src="https://github.com/user-attachments/assets/21b61cba-c50f-4e80-a396-db012631eb14" /> |

---

### 3. 팝업 버튼 클릭음 누락 수정

팝업에서 버튼 클릭 시 클릭음이 나지 않는 곳이 있었습니다.  

#### 수정된 파일

| 파일 | 누락 위치 |
|---|---|
| `SoloDeveloperTrainingApp.swift` | 업데이트 팝업 (force/optional), 오류 팝업 (loadUser/saveUser) |
| `ShopView.swift` | 강화 성공/실패 팝업, 구매 실패 팝업 |
| `SkillView.swift` | 스킬 업그레이드 실패 팝업, 광고 보상 완료 팝업 |

---

### 4. 시나리오 복구와 오프라인 보상 팝업 우선순위 설정

레벨업 시나리오 진행 중 앱을 종료했다가 복귀할 때,  
오프라인 보상 팝업과 시나리오 복구, 레벨업 이펙트가 순서 없이 경쟁하는 구조였습니다.

#### 변경 전 문제점
- `MainView`의 `setupOnAppear()`에서 `restoreScenarioIfNeeded()`와 `checkPendingLevelUp()`을 즉시 호출
- `checkOfflineReward()`는 비동기 Task로 실행되어 오프라인 보상 팝업이 시나리오/레벨업 이펙트 위에 뒤늦게 올라오는 경우 발생

#### 변경 후 처리 순서

- 오프라인 보상 팝업 처리(없으면 생략) → 레벨업 이펙트(없으면 생략) → 시나리오 복구
- `setupOnAppear()`에서 `restoreScenarioIfNeeded()`, `checkPendingLevelUp()` 즉시 호출 제거
- 오프라인 보상 팝업의 모든 출구(보상 없음 / 안받기 / 광고 시청 완료)에서 아래 순서로 처리
  - 1. `checkPendingLevelUp()` 호출
  - 2. 레벨업 이펙트가 없는 경우에만 `restoreScenarioIfNeeded()` 호출
  - 3. 레벨업 이펙트가 있는 경우 `onChange(of: showLevelUpEffect)`에서 `checkAndStartScenario()`가 자동으로 호출되어 시나리오로 이어짐

---

## 확인해주세요

- 타이포그래피 토큰이 변경되어 디자인 QA의 후속작업이 더 생길 수 있을거 같습니다 🤯