### PR TITLE
Housing Card 컴포넌트를 수정하고 부동산 상점화면의 버튼 상태를 수정합니다.

### DIFF
--- a/DUDesignSystem/Sources/DUDesignSystem/Components/Cards/HousingCard.swift
+++ b/DUDesignSystem/Sources/DUDesignSystem/Components/Cards/HousingCard.swift
@@ -12,6 +12,7 @@ public struct HousingCard: View {
     public enum HousingCardState {
         case `default`
         case selected
+        case disabled
         case equipped
         case locked
     }
@@ -44,7 +45,7 @@ public struct HousingCard: View {
 
     private var buttonType: TextButton.TextButtonType {
         switch state {
-        case .default, .selected: return .primary
+        case .default, .selected, .disabled: return .primary
         case .equipped, .locked: return .secondary
         }
     }
@@ -52,7 +53,7 @@ public struct HousingCard: View {
     private var buttonState: TextButton.TextButtonState {
         switch state {
         case .default, .selected: return .default
-        case .equipped: return .locked
+        case .disabled, .equipped: return .disabled
         case .locked: return .locked
         }
     }
@@ -100,10 +101,8 @@ public struct HousingCard: View {
 
     private var buttonText: String {
         switch state {
-        case .default: return "이사하기"
-        case .selected: return "이사하기"
+        case .default, .selected, .disabled, .locked: return "이사하기"
         case .equipped: return "장착중"
-        case .locked: return "이사하기"
         }
     }
 }

--- a/DUDesignSystem/Sources/DUDesignSystem/Components/Cards/HousingCard.swift
+++ b/DUDesignSystem/Sources/DUDesignSystem/Components/Cards/HousingCard.swift
@@ -75,7 +75,7 @@ public struct HousingCard: View {
             Image(imageName, bundle: .module)
                 .resizable()
                 .scaledToFill()
-                .frame(width: 230)
+                .frame(maxWidth: .infinity, minHeight: 0, maxHeight: .infinity)
                 .clipped()
                 .opacity(state == .locked ? TokenOpacity.opacity60 : TokenOpacity.opacity100)
 
@@ -84,6 +84,7 @@ public struct HousingCard: View {
         }
         .padding(.vertical, TokenSpacing.md)
         .frame(width: 230)
+        .frame(maxHeight: .infinity)
         .background(state == .selected ? Color.beige50 : Color.beige100)
         .clipShape(RoundedRectangle(cornerRadius: TokenRadius.sm))
         .overlay(

--- a/SoloDeveloperTraining/SoloDeveloperTraining/GameCore/Models/Items/ItemState.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/GameCore/Models/Items/ItemState.swift
@@ -20,9 +20,9 @@ enum ItemState {
             return
         }
 
-        // 주거 아이템이 이미 장착되어 있으면 잠김
+        // 주거 아이템이 이미 장착되어 있으면 최고 레벨(장착중)
         if item.isEquipped && item.category == .housing {
-            self = .locked
+            self = .reachedMax
             return
         }
 

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/DisplayStateExtensions.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/DisplayStateExtensions.swift
@@ -17,9 +17,10 @@ extension ItemState {
 
     func housingCardState(isSelected: Bool) -> HousingCard.HousingCardState {
         switch self {
-        case .available, .insufficient: return isSelected ? .selected : .default
-        case .locked:                   return .locked
-        case .reachedMax:               return .equipped
+        case .available:    return isSelected ? .selected : .default
+        case .insufficient: return .disabled
+        case .locked:       return .locked
+        case .reachedMax:   return .equipped
         }
     }
 }


### PR DESCRIPTION
## 연관된 이슈

- [#KAN-185](https://devvup.atlassian.net/jira/software/projects/KAN/boards/1/backlog?selectedIssue=KAN-185)
- [#KAN-223](https://devvup.atlassian.net/jira/software/projects/KAN/boards/1/backlog?selectedIssue=KAN-223)

## 작업 내용

### HousingCard 높이 동적 처리

기존에 이미지에 `frame(width: 230)`만 설정되어 있어 `scaledToFill()`이 이미지 원본 비율 기준으로 높이를 고정시키는 문제를 수정했습니다.

- 이미지: `frame(width: 230)` → `frame(minHeight: 0, maxWidth: .infinity, maxHeight: .infinity)`로 변경하여 카드 내 남은 공간을 채우도록 처리
- 카드: `.frame(width: 230).frame(maxHeight: .infinity)`로 너비는 고정, 높이는 부모 컨테이너에 따라 유동적으로 처리
- `minHeight: 0` 추가로 작은 화면에서도 이미지가 정상적으로 축소됨

### HousingCard 상태 버튼 정책 정비

장착중인 카드가 `locked` 상태로 표시되던 문제 및 버튼 상태 정책을 아래와 같이 정리했습니다.

| 상태 | 조건 | 버튼 타입 | 버튼 상태 | 텍스트 |
|------|------|-----------|-----------|--------|
| `default` | 구매 가능 | primary | default | 이사하기 |
| `selected` | 선택됨, 구매 가능 | primary | default | 이사하기 |
| `disabled` | 돈 부족 | primary | disabled | 이사하기 |
| `equipped` | 현재 장착중 | secondary | disabled | 장착중 |
| `locked` | 레벨 제한 | secondary | locked (자물쇠 아이콘) | 이사하기 |

#### 변경 파일

**`HousingCard.swift`**
- `HousingCardState`에 `.disabled` 케이스 추가
- `equipped` 상태 버튼을 `.locked` → `.disabled`로 변경 (자물쇠 아이콘이 "장착중" 텍스트를 가리는 문제 수정)

**`ItemState.swift`**
- 장착중인 주거 아이템의 `ItemState`를 `.locked` → `.reachedMax`로 변경

**`DisplayStateExtensions.swift`**
- `insufficient` → `.disabled` 매핑 추가
- `reachedMax` → `.equipped` 매핑 유지

## 스크린샷

- 은진님에게 디자인 검토 완료


|13mini|17pro|
|---|---|
|<img width="300" alt="image" src="https://github.com/user-attachments/assets/722b1a7c-7c01-46f0-9562-47ae1b69c4a6" />|<img width="300"  alt="image" src="https://github.com/user-attachments/assets/3050b619-ffd3-49e9-8a90-4ab7bdee9939" />|


