### PR TITLE
QA에서 발견한 버그들을 수정합니다.

### DIFF
--- a/DUDesignSystem/Sources/DUDesignSystem/Components/GamePauseWrapper.swift
+++ b/DUDesignSystem/Sources/DUDesignSystem/Components/GamePauseWrapper.swift
@@ -32,7 +32,6 @@ public struct GamePauseWrapper: ViewModifier {
     public func body(content: Content) -> some View {
         ZStack {
             content
-                .blur(radius: pauseBinding ? 2 : 0)
             if pauseBinding {
                 pauseOverlay
                     .transition(TokenTransition.overlay.effect)

--- a/DUDesignSystem/Sources/DUDesignSystem/Components/Items/LanguageItem.swift
+++ b/DUDesignSystem/Sources/DUDesignSystem/Components/Items/LanguageItem.swift
@@ -34,14 +34,14 @@ public struct LanguageItem: View {
         switch state {
         case .completed: return 38
         case .upcoming:  return 38
-        case .active:    return 52
+        case .active:    return 60
         }
     }
 
     private var opacity: Double {
         switch state {
         case .completed: return TokenOpacity.opacity20
-        case .upcoming:  return TokenOpacity.opacity100
+        case .upcoming:  return TokenOpacity.opacity80
         case .active:    return TokenOpacity.opacity100
         }
     }

--- a/DUDesignSystem/Sources/DUDesignSystem/Components/Items/LanguageItemButton.swift
+++ b/DUDesignSystem/Sources/DUDesignSystem/Components/Items/LanguageItemButton.swift
@@ -22,7 +22,7 @@ public struct LanguageItemButton: View {
     public var body: some View {
         VStack(spacing: TokenSpacing.sm) {
             LanguageItem(language: language, state: .upcoming)
-            ItemLabel(text: language.rawValue.replacingOccurrences(of: "language_", with: "").capitalized, font: .caption, color: .black300)
+            ItemLabel(text: language.rawValue.replacingOccurrences(of: "language", with: "").capitalized, font: .caption, color: .black300)
         }
         .padding(.vertical, TokenSpacing.sm)
         .frame(width: 64)

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Work/Game/DodgeGameView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Work/Game/DodgeGameView.swift
@@ -190,7 +190,7 @@ private extension DodgeGameView {
     var effectLabelsSection: some View {
         ZStack {
             ForEach(effectLabels) { effect in
-                EffectLabel(type: effect.value >= 0 ? .plus : .minus, text: "\(abs(effect.value))") {
+                EffectLabel(type: effect.value >= 0 ? .plus : .minus, text: abs(effect.value).formatted) {
                     removeEffectLabel(id: effect.id)
                 }
                 .position(effect.position)

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Work/Game/LanguageGameView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Work/Game/LanguageGameView.swift
@@ -159,7 +159,7 @@ private extension LanguageGameView {
         .overlay(alignment: .top) {
             ZStack {
                 ForEach(effectLabels) { data in
-                    EffectLabel(type: data.value >= 0 ? .plus : .minus, text: "\(abs(data.value))") {
+                    EffectLabel(type: data.value >= 0 ? .plus : .minus, text: abs(data.value).formatted) {
                         removeEffectLabel(id: data.id)
                     }
                 }

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Work/Game/QuizGameView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Work/Game/QuizGameView.swift
@@ -37,6 +37,7 @@ struct QuizGameView: View {
             Spacer()
             optionsSection
         }
+        .ignoresSafeArea(edges: [.top, .bottom])
         .analyticsScreen(screenID)
         .padding(.horizontal, TokenGrid.paddingSide)
         .background(Color.beige50)
@@ -122,7 +123,7 @@ struct QuizGameView: View {
                     ItemLabel(
                         text: quizGame.currentAnswerResult?.isCorrect == true ?
                         "정답\n\(quizGame.currentQuestion?.explanation ?? "")" :
-                            "오답\n\(quizGame.currentQuestion?.explanation ?? "")",
+                        "오답 / 정답은 \((quizGame.currentQuestion?.correctAnswerIndex ?? 0) + 1)번이다.\n\(quizGame.currentQuestion?.explanation ?? "")",
                         font: .label,
                         color: quizGame.currentAnswerResult?.isCorrect == true ? .accentGreen : .accentRed,
                         textAlignment: .leading

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Work/Game/StackGameView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Work/Game/StackGameView.swift
@@ -111,7 +111,7 @@ private extension StackGameView {
                 SpriteView(scene: scene)
 
                 ForEach(effectLabels) { effect in
-                    EffectLabel(type: effect.value >= 0 ? .plus : .minus, text: "\(abs(effect.value))") {
+                    EffectLabel(type: effect.value >= 0 ? .plus : .minus, text: abs(effect.value).formatted) {
                         removeEffectLabel(id: effect.id)
                     }
                     .position(effect.position)

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Work/Game/TapGameView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Work/Game/TapGameView.swift
@@ -115,7 +115,7 @@ private extension TapGameView {
                 .clipped()
 
             ForEach(effectLabels) { data in
-                EffectLabel(type: .plus, text: "\(data.value)") {
+                EffectLabel(type: .plus, text: data.value.formatted) {
                     removeEffectLabel(id: data.id)
                 }
                 .position(data.position)


### PR DESCRIPTION
## 연관된 이슈

- [#KAN-198](https://devvup.atlassian.net/jira/software/projects/KAN/boards/1/backlog?selectedIssue=KAN-198)
- [#KAN-201](https://devvup.atlassian.net/jira/software/projects/KAN/boards/1/backlog?selectedIssue=KAN-201)
- [#KAN-205](https://devvup.atlassian.net/jira/software/projects/KAN/boards/1/backlog?selectedIssue=KAN-205)
- [#KAN-221](https://devvup.atlassian.net/jira/software/projects/KAN/boards/1/backlog?selectedIssue=KAN-221)
- [#KAN-231](https://devvup.atlassian.net/jira/software/projects/KAN/boards/1/backlog?selectedIssue=KAN-231)
- [#KAN-234](https://devvup.atlassian.net/jira/software/projects/KAN/boards/1/backlog?selectedIssue=KAN-234) 

## 작업 내용

### EffectLabel 골드 수치 단축 표기 적용

미니게임(TapGame, StackGame, DodgeGame, LanguageGame)에서 골드 획득/손실 시 표시되는 EffectLabel에 `Int.formatted`를 적용했습니다.

- 기존: `"\(abs(value))"` → 변경: `abs(value).formatted`
- 1,000 이상부터 K / M / B / T 단위로 단축 표기

### 퀴즈 오답 시 정답 번호 표시

퀴즈 게임에서 오답 선택 후 제출 시 정답 번호를 함께 표시하도록 수정했습니다.

- 기존: `오답\n{설명}`
- 변경: `오답 / 정답은 @번이다.\n{설명}`

### LanguageItem / LanguageItemButton 디자인 스펙 반영

- LanguageItem 디자인 스펙에 맞게 수정
- LanguageItemButton 텍스트 수정

### GamePauseWrapper blur 제거

- 게임 일시정지 시 적용되던 blur 효과 제거