### PR TITLE
오프라인 보상 팝업 트리거 문제 해결

### DIFF
--- a/SoloDeveloperTraining/SoloDeveloperTraining/App/SoloDeveloperTrainingApp.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/App/SoloDeveloperTrainingApp.swift
@@ -151,7 +151,7 @@ private extension SoloDeveloperTrainingApp {
             guard user == nil else { return }
             loadUser()
         }
-        .onChange(of: scenePhase) { _, newPhase in
+        .onChange(of: scenePhase) { oldPhase, newPhase in
             if newPhase == .active {
                 SessionManager.shared.handleForeground()
                 if SessionManager.shared.didStartNewSession, let user {
@@ -163,14 +163,14 @@ private extension SoloDeveloperTrainingApp {
                     )
                     SessionManager.shared.consumeNewSession()
                 }
-            } else if newPhase == .background || newPhase == .inactive {
-                SessionManager.shared.handleBackground()
-                saveUser()
-
-                if newPhase == .background {
-                    let level = user?.career.level ?? 0
-                    AnalyticsService.shared.logAppDeparture(level: level)
+            } else if newPhase == .inactive {
+                if oldPhase == .active {
+                    SessionManager.shared.handleBackground()
+                    saveUser()
                 }
+            } else if newPhase == .background {
+                let level = user?.career.level ?? 0
+                AnalyticsService.shared.logAppDeparture(level: level)
             }
         }
     }

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/MainView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/MainView.swift
@@ -581,7 +581,7 @@ private extension MainView {
             offlineRewardGold = gold
             offlineRewardHours = hoursElapsed
             showOfflineRewardPopup()
-        case .notEligible(_):
+        case .notEligible:
             hasCheckedOfflineReward = false
             checkPendingLevelUp()
             if !showLevelUpEffect {

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Utility/TimeValidator.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Utility/TimeValidator.swift
@@ -58,7 +58,7 @@ enum TimeValidator {
         savedTime: TimeInterval,
         currentTime: TimeInterval
     ) -> Bool {
-        let elapsed = currentTime - savedTime
-        return elapsed >= Policy.OfflineReward.minimumHours
+        let elapsedTimeSecond = currentTime - savedTime
+        return elapsedTimeSecond >= Policy.OfflineReward.minimumHours * 3600
     }
 }


### PR DESCRIPTION
## 연관된 이슈

- [KAN-211](https://devvup.atlassian.net/browse/KAN-211)
- [KAN-186](https://devvup.atlassian.net/browse/KAN-186)

## 작업 내용 및 고민 내용
 
### 올바른 시간 저장 및 로드 여부 확인
- 처음에는 시간이 잘 저장되지 않는 문제인지 알고, 로그를 찍어본 결과 마지막으로 저장된 시간과 다음 빌드에서 앱을 실행했을 때 찍히는 시간이 일치해 저장 문제는 아닌 것으로 확인했습니다.
 
### `TimeValidator`의 시간 계산 로직 수정
- 해당 유틸의 `hasEnoughTimePassed` 메소드 내에서, '초' 단위로 저장된 시간과 현재 시간을 받아 '시간' 단위와 비교하고 있어 항상 true를 반환하는 것이 팝업이 뜨는 문제의 원인임을 확인했습니다.
- 따라서 시간에 3600을 곱해 '초' 단위로 만든 후 비교하도록 수정했습니다. 

### 앱의 생명주기에 대한 background, inactive 트리거 분리
#### 문제
- `scenePhase`의 `.inactive`, `.background` 상태를 OR 조건으로 묶어 처리하고 있어 다음과 같은 문제가 있었습니다.
  - **중복 실행**: 앱이 완전히 백그라운드로 진입하는 과정(`.active → .inactive → .background`)에서 `.inactive`와 `.background` 두 상태 전이가 모두 조건을 만족시켜, `saveUser()`와 세션 관련 로그 이벤트가 한 번의 종료 동작에도 중복으로 실행됨
  - **`lastExitTime` 오염**: 앱 재진입 경로(`.background → .inactive → .active`) 역시 `.inactive`를 거치기 때문에, 앱을 종료할 때뿐 아니라 **다시 진입했을 때도** `recordExitTime()`이 실행되어 `lastExitTime`이 재진입 시점으로 덮어써짐
    - 실제 종료 시점 기준으로 계산되어야 할 오프라인 경과 시간이 잘못 기록됨

#### 해결
- `.inactive`, `.background` 두 트리거 조건을 분리하고, `oldPhase`를 함께 확인해 "나가는 방향의 전이"인지 "재진입 방향의 전이"인지 구분하도록 수정했습니다.
- 이를 통해 저장 및 로깅 로직이 각 상태 전이당 정확히 한 번씩만, 그리고 올바른 방향(종료 시점)에서만 실행되도록 보장했습니다.

## 스크린샷
- inactive 상태 진입 및 앱 종료 후 재시작 시 팝업이 뜨지 않는 것을 확인했습니다.
 
https://github.com/user-attachments/assets/edf796b0-39a9-4f3d-8542-f776b097f771