### PR TITLE
시나리오 관련 기능을 수정합니다.

### DIFF
--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/LevelUpEffectView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/LevelUpEffectView.swift
@@ -26,6 +26,7 @@ struct LevelUpEffectView: View {
     let currentCareerTitle: String
 
     @State private var phase: Phase = .start
+    @State private var isInProgress: Bool = false
     @State private var showTitleBox: Bool = false
     @State private var gradientOpacity: CGFloat = 0
     @State private var titleText: String = ""
@@ -35,7 +36,9 @@ struct LevelUpEffectView: View {
             Color.black300EventDim
                 .ignoresSafeArea()
                 .onTapGesture {
-                    isPresented = false
+                    if !isInProgress {
+                        isPresented = false
+                    }
                 }
 
             VStack(spacing: TokenSpacing.xs) {
@@ -116,6 +119,7 @@ private extension LevelUpEffectView {
 // MARK: - helpers
 private extension LevelUpEffectView {
     func startAnimation() {
+        isInProgress = true
         guard phase == .start else { return }
 
         showTitleBox = false
@@ -133,6 +137,8 @@ private extension LevelUpEffectView {
         withAnimation(TokenAnimation.crossFade.animation) {
             gradientOpacity = 1
             titleText = currentCareerTitle
+        } completion: {
+            isInProgress = false
         }
     }
 }

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/LevelUpEffectView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/LevelUpEffectView.swift
@@ -137,7 +137,10 @@ private extension LevelUpEffectView {
         withAnimation(TokenAnimation.crossFade.animation) {
             gradientOpacity = 1
             titleText = currentCareerTitle
-        } completion: {
+        }
+
+        Task { @MainActor in
+            try? await Task.sleep(for: .seconds(1))
             isInProgress = false
         }
     }

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/MainView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/MainView.swift
@@ -114,6 +114,11 @@ struct MainView: View {
             }
         }
         .animation(TokenTransition.overlay.animation, value: showLevelUpEffect)
+        .onChange(of: showLevelUpEffect) { _, isPresented in
+            if isPresented && workGameSession.isInProgress {
+                workGameSession.isPauseRequested = true
+            }
+        }
         .onChange(of: workGameSession.showsExitBonusPopup) { _, shows in
             if shows { showExitBonusPopup() }
         }


### PR DESCRIPTION
## 연관된 이슈

- [KAN-189](https://devvup.atlassian.net/browse/KAN-189)
- ~[KAN-192](https://devvup.atlassian.net/browse/KAN-192)~ 홀딩됨
- [KAN-232](https://devvup.atlassian.net/browse/KAN-232)

## 작업 내용 및 고민 내용
### 레벨업 표시 트리거 발생 시, 게임이 진행 중이면 일시 정지
- showLevelupEffect 트리거 값이 변경될 경우, workGameSession 객체를 통해 게임이 진행 중인지 확인하고, 진행 중일 경우 멈추도록 로직을 추가했습니다.

### 레벨업 표시중 화면 터치 제한
- LevelupEffectView 내부에서 State 변수를 추가하여, `Task.sleep(for: .seconds(1.5))`로 일정 시간 뒤부터 Tap gesture가 인식되도록 수정했습니다.

### 시나리오 선택 이벤트 A/B 동시 클릭 이슈
- 해당 이슈는 홀딩되었습니다.
- 관련 내용 및 결정 사항은 [지라](https://devvup.atlassian.net/browse/KAN-192?focusedCommentId=11387)를 참고해주세요!

## 스크린샷

<img width="295" height="640" alt="Simulator Screen Recording - iPhone 17 - 2026-07-07 at 18 49 35" src="https://github.com/user-attachments/assets/b6043047-9f57-46ef-947e-997b4289c8ae" />


