### PR TITLE
earnMoney 미호출 부분 earnMoney추가

### DIFF
--- a/SoloDeveloperTraining/SoloDeveloperTraining/Devlopment/Presentation/MissionTestView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Devlopment/Presentation/MissionTestView.swift
@@ -619,7 +619,7 @@ struct MissionTestView: View {
             return
         }
 
-        missionSystem.claimMissionReward(mission: mission, wallet: wallet)
+        missionSystem.claimMissionReward(mission: mission, wallet: wallet, record: record)
 
         var message = "미션 '\(mission.title)' 보상을 수령했습니다!\n"
         if mission.reward.gold > 0 {

--- a/SoloDeveloperTraining/SoloDeveloperTraining/GameCore/Models/Systems/MissionSystem.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/GameCore/Models/Systems/MissionSystem.swift
@@ -38,10 +38,11 @@ final class MissionSystem {
         checkHasCompletedMission()
     }
 
-    func claimMissionReward(mission: Mission, wallet: Wallet) {
+    func claimMissionReward(mission: Mission, wallet: Wallet, record: Record) {
         let reward = mission.claim()
         wallet.addGold(reward.gold)
         wallet.addDiamond(reward.diamond)
+        record.record(.earnMoney(reward.gold))
 
         sortMissions()
         checkHasCompletedMission()

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/MainView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/MainView.swift
@@ -624,6 +624,7 @@ private extension MainView {
                 adWatchDurationSec: result.watchDurationSec
             )
             user.wallet.addGold(offlineRewardGold)
+            user.record.record(.earnMoney(offlineRewardGold))
             ToastManager.shared.show("잠자는 시간에 일한 보상 획득!")
             AnalyticsService.shared.logAdRewardClaimed(
                 adRewardFlowID: flowID,

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/MissionView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/MissionView.swift
@@ -54,7 +54,7 @@ struct MissionView: View {
 private extension MissionView {
     func missionCardDidTapHandler(mission: Mission) {
         if mission.missionCardState == .claimable {
-            missionSystem.claimMissionReward(mission: mission, wallet: user.wallet)
+            missionSystem.claimMissionReward(mission: mission, wallet: user.wallet, record: user.record)
             SoundService.shared.trigger(.mission)
             let reward = mission.reward
             if reward.gold > 0 && reward.diamond > 0 {


### PR DESCRIPTION
## 연관된 이슈

- [KAN-206](https://devvup.atlassian.net/jira/software/projects/KAN/boards/1/backlog?jql=assignee%20%3D%20712020%3A16b5d74f-98d7-4e47-91fe-dc4c4a0303f2&selectedIssue=KAN-206)

## 작업 내용

### 커리어 누적 획득 재화 누락 버그 수정

지갑 잔액보다 커리어 누적 재화가 적게 표시되는 버그를 수정했습니다.

**원인**
골드가 지갑(`wallet.addGold`)에는 추가되지만 누적 재산(`record.earnMoney`)에는 기록되지 않는 경로가 2곳 존재했습니다.

**수정 위치**

- `MainView.swift` — 오프라인 보상 광고 시청 후 골드 수령 시 `earnMoney` 미기록
- `MissionSystem.swift` — 미션 보상 수령 시 `earnMoney` 미기록
  → `claimMissionReward(mission:wallet:record:)` 시그니처에 `record` 파라미터 추가

## 확인해주세요

- 오프라인 보상 광고 시청 후 커리어 누적 재화가 증가하는지 확인
- 미션 보상 수령 후 커리어 누적 재화가 증가하는지 확인
- 커리어 팝업에서 누적 재화가 지갑 잔액 이상으로 표시되는지 확인
