### PR TITLE
캐릭터가 재화를 획득할 때 웃지 않는 문제를 개선하고 Token값을 변경합니다.

### DIFF
--- a/DUDesignSystem/Sources/DUDesignSystem/Token/TokenGrid.swift
+++ b/DUDesignSystem/Sources/DUDesignSystem/Token/TokenGrid.swift
@@ -10,8 +10,8 @@ import CoreGraphics
 /// Figma 디자인 시스템 "개발자 키우기"의 그리드 토큰입니다.
 public enum TokenGrid {
     public static let paddingSide:        CGFloat = 16
-    public static let paddingTop:         CGFloat = 60
-    public static let paddingBottom:      CGFloat = 36
+    public static let paddingTop:         CGFloat = 72
+    public static let paddingBottom:      CGFloat = 48
     public static let marginPopUp:        CGFloat = 24
     public static let marginBottomLarge:  CGFloat = 60
 }

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/CharacterScene.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/CharacterScene.swift
@@ -20,6 +20,7 @@ final class CharacterScene: SKScene {
     // MARK: - Properties
     private var characterSprite: SKSpriteNode?
     private var user: User
+    private var isSmiling = false
 
     init(size: CGSize, user: User) {
         self.user = user
@@ -60,7 +61,8 @@ final class CharacterScene: SKScene {
 
     /// 캐릭터를 웃게 만들기
     func playSmile() {
-        guard let sprite = characterSprite else { return }
+        guard let sprite = characterSprite, !isSmiling else { return }
+        isSmiling = true
         // 깜빡임 애니메이션 일시 중지
         sprite.removeAction(forKey: AnimationKey.blink)
         // 웃는 애니메이션
@@ -70,6 +72,7 @@ final class CharacterScene: SKScene {
             SKAction.setTexture(idleTexture),
             SKAction.run { [weak self] in
                 // 웃음 애니메이션 끝나면 다시 깜빡임 시작
+                self?.isSmiling = false
                 self?.startBlinking()
             }
         ])


### PR DESCRIPTION
## 연관된 이슈

- [KAN-245](https://devvup.atlassian.net/jira/software/projects/KAN/boards/1/backlog?jql=assignee%20%3D%20712020%3A16b5d74f-98d7-4e47-91fe-dc4c4a0303f2&selectedIssue=KAN-245)
- [KAN-184](https://devvup.atlassian.net/jira/software/projects/KAN/boards/1/backlog?jql=assignee%20%3D%20712020%3A16b5d74f-98d7-4e47-91fe-dc4c4a0303f2&selectedIssue=KAN-184)

## 작업 내용

### 재화 획득 시 캐릭터 웃음 애니메이션이 가끔 동작하지 않는 버그 수정

#### 원인

`CharacterScene.playSmile()`에서 `sprite.run(smile, withKey: "smile")`을 사용하고 있었는데,
같은 key로 실행 중인 액션이 있을 때 새 호출이 오면 **기존 액션을 즉시 중단**시키는 SpriteKit의 동작 때문에
시퀀스 마지막 단계인 `startBlinking()` 콜백이 호출되지 않는 케이스가 발생했습니다.

TapGame 연타, DodgeGame 골드 연속 수집처럼 **재화를 빠르게 연속 획득**할 때 이 상황이 반복되면
blink도 smile도 동작하지 않는 상태로 캐릭터가 멈추는 현상이 발생했습니다.

#### 수정 방안 검토

**Option A — 웃는 중이면 스킵**
`isSmiling` 플래그로 중복 호출을 차단해 현재 웃음이 끝난 뒤에만 다음 웃음을 시작.
`startBlinking()` 호출이 항상 보장됨.

**Option B — 웃는 중이면 duration 연장**
기존 smile 액션을 제거하고 대기 시간만 리셋해 웃음이 자연스럽게 이어지도록 함.

#### 선택: Option A

웃음 지속시간(0.5초)이 짧아 스킵돼도 유저가 체감하기 어렵고,
상태 관리가 단순해 `startBlinking()` 누락 버그 재발 가능성이 없는 A를 선택했습니다.

```swift
private var isSmiling = false

func playSmile() {
    guard let sprite = characterSprite, !isSmiling else { return }
    isSmiling = true
    ...
    SKAction.run { [weak self] in
        self?.isSmiling = false
        self?.startBlinking()
    }
}
```

### 그리드 토큰 수정

- `TokenGrid.paddingTop`: 60 → 72
- `TokenGrid.paddingBottom`: 36 → 48