### PR TITLE
SkillView의 Row Description을 수정합니다.

### DIFF
--- a/SoloDeveloperTraining/SoloDeveloperTraining/GameCore/Models/Systems/SkillSystem.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/GameCore/Models/Systems/SkillSystem.swift
@@ -45,9 +45,12 @@ final class SkillSystem {
 
         var totalByGame: [GameType: Double] = [:]
         for game in GameType.allCases {
-            totalByGame[game] = skillList
+            let total = skillList
                 .filter { $0.key.game == game }
                 .reduce(0.0) { $0 + $1.gainGold }
+            totalByGame[game] = game == .dodge
+                ? total * Policy.Game.Dodge.bugDodgeGoldMultiplier
+                : total
         }
 
         return skillList.map { skill in

--- a/SoloDeveloperTraining/SoloDeveloperTraining/GameCore/Models/Systems/SkillSystem.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/GameCore/Models/Systems/SkillSystem.swift
@@ -10,6 +10,7 @@ import Foundation
 struct SkillState {
     let skill: Skill
     let itemState: ItemState
+    let totalGainGold: Double
 }
 
 final class SkillSystem {
@@ -39,12 +40,23 @@ final class SkillSystem {
             let bucketIndex = gameIndex * skillTierCount + tierIndex
             buckets[bucketIndex] = skill
         }
-        return buckets
-            .compactMap { $0 }
-            .map { skill in SkillState(
+
+        let skillList = buckets.compactMap { $0 }
+
+        var totalByGame: [GameType: Double] = [:]
+        for game in GameType.allCases {
+            totalByGame[game] = skillList
+                .filter { $0.key.game == game }
+                .reduce(0.0) { $0 + $1.gainGold }
+        }
+
+        return skillList.map { skill in
+            SkillState(
                 skill: skill,
-                itemState: getItemState(for: skill))
-            }
+                itemState: getItemState(for: skill),
+                totalGainGold: totalByGame[skill.key.game] ?? 0
+            )
+        }
     }
 
     /// 스킬 항목을 구매하여 레벨 업그레이드

--- a/SoloDeveloperTraining/SoloDeveloperTraining/GameCore/Models/User/Skill/Skill.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/GameCore/Models/User/Skill/Skill.swift
@@ -71,6 +71,11 @@ final class Skill: Hashable {
         return Double(baseGold + multiplier * level)
     }
 
+    /// 레벨업 시 획득 재화 증가량
+    var gainGoldIncrease: Double {
+        return gainGoldAfterUpgrade - gainGold
+    }
+
     /// 레벨업 시 획득 재화량 (스킬에 국한된 스탯)
     var gainGoldAfterUpgrade: Double {
         let baseGold: Int

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/SkillView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/SkillView.swift
@@ -58,9 +58,9 @@ struct SkillView: View {
                         imageName: skillState.skill.imageName,
                         title: skillState.skill.title,
                         description: {
-                            let current = skillState.skill.gainGold
-                            let after = skillState.skill.gainGoldAfterUpgrade
-                            return "레벨업시 골드 획득 \(Int(current).formatted) -> \(Int(after).formatted)"
+                            let increase = skillState.skill.gainGoldIncrease
+                            let total = skillState.totalGainGold
+                            return "액션 당 +\(Int(increase).formatted) 획득 / 현재 \(Int(total).formatted)"
                         }(),
                         buttonType: skillState.skill.upgradeCost.itemButtonType,
                         buttonState: skillState.itemState.itemButtonState,

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/SkillView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/SkillView.swift
@@ -36,7 +36,7 @@ struct SkillView: View {
         return ItemRow(
             imageName: "adBoost",
             title: "업무 효율 대박",
-            description: "5분간 피버타임 두배 (X1, X2, X4)",
+            description: "5분간 피버 타임 (업무 보상 X2)",
             buttonType: .singleLine(text: isActive ? "사용중" : "광고보기", icon: .ad),
             buttonState: buttonState,
             action: {


### PR DESCRIPTION
## 연관된 이슈

- [KAN-213](https://devvup.atlassian.net/browse/KAN-213)
  - [KAN-219](https://devvup.atlassian.net/browse/KAN-219)
- [KAN-210](https://devvup.atlassian.net/browse/KAN-210)

## 작업 내용 및 고민 내용

### 1. 업무 보상 두배 광고 설명 수정

<img height="80" alt="image" src="https://github.com/user-attachments/assets/4a6be5ab-b18c-4781-ad34-8db0e18ad638" />

업무 보상을 두배로 만들어주는 광고 Row의 description을 수정했습니다.

---

### 2. 스킬 레벨업 설명 수정

| 탭, 언어 | 버그, 데이터 |
| --- | --- |
| <img height="650" alt="IMG_1015" src="https://github.com/user-attachments/assets/f34a7826-2d13-48dc-9b31-3f68117430e4" /> | <img height="650" alt="IMG_1016" src="https://github.com/user-attachments/assets/b8ac8099-aac2-41fc-b705-c34a8f6383ed" /> |

- description을
"액션당 +\(`업그레이드 했을 때 증가되는 수치 Policy로부터 가져옵니다.`) / 현재 \(`해당 게임에서 액션당 얻는 수치`)"
에 맞게 적용하였습니다.  
- dodgeGame은 `Policy.Game.Dodge.bugDodgeGoldMultiplier`(*0.5) 자체적 밸런스가 적용되어있어서 description에도 적용하였습니다.
