### PR TITLE
시나리오 관련 UI, 이미지 저장 오류를 해결합니다.

### DIFF
--- a/DUDesignSystem/Sources/DUDesignSystem/Components/Cards/StoryCard.swift
+++ b/DUDesignSystem/Sources/DUDesignSystem/Components/Cards/StoryCard.swift
@@ -64,13 +64,13 @@ private extension StoryCard {
             Image(imageName, bundle: .module)
                 .resizable()
                 .scaledToFill()
-                .frame(width: geo.size.width)
+                .frame(width: geo.size.width, height: type.imageHeight)
                 .clipped()
-                .overlay(alignment: .bottom) {
-                    TextBox(text: text)
-                }
         }
         .frame(height: type.imageHeight)
+        .overlay(alignment: .bottom) {
+            TextBox(text: text)
+        }
     }
 
     func headerView(title: String) -> some View {

--- a/SoloDeveloperTraining/DUDesignSystemExample/Component/ComponentStoryCardView.swift
+++ b/SoloDeveloperTraining/DUDesignSystemExample/Component/ComponentStoryCardView.swift
@@ -26,7 +26,7 @@ struct ComponentStoryCardView: View {
                     StoryCard(
                         type: storyCardType,
                         text: description,
-                        imageName: viewMode == .levelUp ? "scenarioLevelupNormalDeveloper" : "geniusHacker"
+                        imageName: viewMode == .levelUp ? "normalDeveloper1" : "geniusHacker"
                     )
                 }
 

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Data/Repository/DefaultScenarioRepository.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Data/Repository/DefaultScenarioRepository.swift
@@ -393,7 +393,7 @@ final class DefaultScenarioRepository: ScenarioRepository {
             pages: [
                 ScenarioPage(
                     imageName: "worldClassDeveloper1",
-                    text: "여기 코드가 가능해진 지금,\n누군가는 당신을 개발자라 부르고...",
+                    text: "0과 1로 대화가 가능해진 지금,\n누군가는 당신을 개발자라 부르고...",
                     pageType: .story
                 ),
                 ScenarioPage(

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Scenario/ScenarioStoryView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Scenario/ScenarioStoryView.swift
@@ -335,7 +335,7 @@ private extension ScenarioStoryView {
 
         let renderer = ImageRenderer(content: targetView)
         renderer.scale = UIScreen.main.scale
-        renderer.isOpaque = false
+        renderer.isOpaque = true
         return renderer.uiImage
     }
 

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Scenario/ScenarioStoryView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Scenario/ScenarioStoryView.swift
@@ -37,60 +37,14 @@ struct ScenarioStoryView: View {
         self._currentPageIndex = State(initialValue: manager.currentPageIndex)
     }
 
-    var isEnding: Bool { finalEnding != nil }
-
     var body: some View {
-        ZStack {
-            VStack(spacing: TokenSpacing.lg) {
-                if isEnding { endingResultView }
-
-                if let ending = finalEnding {
-                    StoryCard(
-                        type: .ending(title: ending.type.title),
-                        text: ending.type.description,
-                        imageName: ending.type.imageName
-                    )
-                    .id("ending")
-                    .padding(.bottom, TokenSpacing.sm)
-                } else if let page = manager.currentPage {
-                    StoryCard(
-                        type: .levelUp,
-                        text: page.text,
-                        imageName: page.imageName ?? ""
-                    )
-                    .id(currentPageIndex)
-                }
-
-                if let ending = finalEnding {
-                    EventButton(type: .ending(
-                        onSave: {
-                            SoundService.shared.trigger(.click)
-                            guard let image = renderEndingImage(ending) else { return }
-                            PhotoLibraryService.saveImageToPhotoLibrary(image) { success in
-                                ToastManager.shared.show(success ? "이미지가 저장되었습니다." : "사진 접근 허용이 필요해요!", anchor: .center)
-                            }
-                        },
-                        onShare: {
-                            SoundService.shared.trigger(.click)
-                            currentShareID = UUID().uuidString
-                            AnalyticsService.shared
-                                .logShareButtonClicked(
-                                    shareID: currentShareID,
-                                    resultID: ending.id,
-                                    shareChannel: ShareChannel.unknown.rawValue
-                                )
-                            PopupManager.shared.show { shareSheetPopup }
-                        },
-                        onRebirth: {
-                            SoundService.shared.trigger(.click)
-                            PopupManager.shared.show { rebirthConfirmPopupView }
-                        }
-                    ))
-                } else if let page = manager.currentPage {
-                    eventButtonView(for: page)
-                }
+        Group {
+            if let ending = finalEnding {
+                endingResultView(ending: ending)
+                    .frame(maxHeight: .infinity, alignment: .top)
+            } else if let page = manager.currentPage {
+                scenarioView(page: page)
             }
-            .frame(maxHeight: .infinity, alignment: isEnding ? .top : .center)
         }
         .analyticsScreen(
             ScreenID
@@ -129,21 +83,67 @@ private extension ScenarioStoryView {
         }
     }
 
-    var endingResultView: some View {
-        HStack(spacing: TokenSpacing.sm) {
-            DUIcon(.movieSlate, size: .size28)
-            Text("엔딩 결과").duFont(.title1).foregroundStyle(Color.white300)
-            Spacer()
-            Button(action: {
-                SoundService.shared.trigger(.click)
-                onComplete()
-            }) {
-                DUIcon(.close, size: .size28)
-            }
+    func scenarioView(page: ScenarioPage) -> some View {
+        VStack(spacing: TokenSpacing.lg) {
+            StoryCard(
+                type: .levelUp,
+                text: page.text,
+                imageName: page.imageName ?? ""
+            )
+            .id(currentPageIndex)
+            eventButtonView(for: page)
         }
-        .frame(height: 30)
+    }
+
+    func endingResultView(ending: Ending) -> some View {
+        VStack(spacing: TokenSpacing.none) {
+            HStack(spacing: TokenSpacing.sm) {
+                DUIcon(.movieSlate, size: .size28)
+                Text("엔딩 결과").duFont(.title1).foregroundStyle(Color.white300)
+                Spacer()
+                Button(action: {
+                    SoundService.shared.trigger(.click)
+                    onComplete()
+                }, label: { DUIcon(.close, size: .size28) })
+            }
+            .frame(height: 30)
+            .padding([.bottom, .horizontal], TokenSpacing.lg)
+
+            StoryCard(
+                type: .ending(title: ending.type.title),
+                text: ending.type.description,
+                imageName: ending.type.imageName
+            )
+            .id("ending")
+            .padding(.top, TokenSpacing.lg)
+            .padding(.bottom, TokenSpacing.xl)
+
+            EventButton(type: .ending(
+                onSave: {
+                    SoundService.shared.trigger(.click)
+                    guard let image = renderEndingImage(ending) else { return }
+                    PhotoLibraryService.saveImageToPhotoLibrary(image) { success in
+                        ToastManager.shared.show(success ? "이미지가 저장되었습니다." : "사진 접근 허용이 필요해요!", anchor: .center)
+                    }
+                },
+                onShare: {
+                    SoundService.shared.trigger(.click)
+                    currentShareID = UUID().uuidString
+                    AnalyticsService.shared
+                        .logShareButtonClicked(
+                            shareID: currentShareID,
+                            resultID: ending.id,
+                            shareChannel: ShareChannel.unknown.rawValue
+                        )
+                    PopupManager.shared.show { shareSheetPopup }
+                },
+                onRebirth: {
+                    SoundService.shared.trigger(.click)
+                    PopupManager.shared.show { rebirthConfirmPopupView }
+                }
+            ))
+        }
         .padding(.top, TokenGrid.paddingTop)
-        .padding([.bottom, .horizontal], TokenSpacing.lg)
     }
 
     var rebirthConfirmPopupView: some View {

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Utility/PhotoLibraryService.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Utility/PhotoLibraryService.swift
@@ -13,7 +13,7 @@ enum PhotoLibraryService {
         completion: @escaping (Bool) -> Void
     ) {
         PHPhotoLibrary.requestAuthorization(for: .addOnly) { status in
-            DispatchQueue.main.async {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
                 completion(status == .authorized || status == .limited)
             }
         }


### PR DESCRIPTION
## 연관된 이슈

- [KAN-237](https://devvup.atlassian.net/browse/KAN-237)
- [KAN-238](https://devvup.atlassian.net/browse/KAN-238)
- [KAN-239](https://devvup.atlassian.net/browse/KAN-239)

## 작업 내용 및 고민 내용
### DUDesignSystemExample
- 존재하지 않는 이미지를 사용하고 있어서, 존재하는 이미지로 대체했습니다.
----

### 시나리오 텍스트 오류를 수정했습니다.

### StoryCard 레이아웃 문제 해결
- `ScenarioStoryView`에서 `StoryCard`와 버튼 사이 간격이 지정해준 `TokenSpacing.lg`보다 좁아보이는 문제가 있었습니다.

- `StoryCard` 컴포넌트의 `cardContent`에서 Image에 width만 고정하고 height는 지정하지 않아, `scaledToFill()`에 의해 이미지의 실제 렌더링 높이가 비율에 따라 외부에서 지정한 크기보다 커지고 있었습니다.
- 따라서 계산된 레이아웃에서 '실제로 넘친 크기만큼' 여백이 줄어들어 발생한 문제였습니다. Image에도 높이를 직접 지정해주어 해결했습니다.

### `ScenarioStoryView` 레이아웃 재구성
- 엔딩인 경우와 엔딩이 아닌 경우를 분리하여, 가독성을 개선했습니다.
- 불필요한 ZStack을 제거했습니다.

### 최초 이미지 저장 권한 허용 후 토스트 알림 표시 문제
- 최초 이미지 저장시 권한 허용 팝업 노출시점과 토스트 알림 표시 시점이 충돌하여 토스트가 씹히는 문제가 있었습니다.
- GCD의 async > asyncAfter로 변경하여 `requestAuthorization`의 팝업이 사라진 시점 이후에 completion이 실행되도록 수정해 해결했습니다.

### 엔딩 카드 저장 시 발생한 에러 해결
- 엔딩 카드 이미지에 알파값이 존재하지 않는데, 렌더링된 이미지를 저장할 때 `isOpaque = false` 옵션을 설정하고 있어 오류가 발생했음을 확인했고, 명시적으로 `true`로 변경했습니다.

## 스크린샷

<img width="200"  alt="Simulator Screenshot - iPhone 17 - 2026-07-08 at 17 04 33" src="https://github.com/user-attachments/assets/8153d6fa-866f-453c-aaf8-99a945449d3e" />

<img width="200" alt="image" src="https://github.com/user-attachments/assets/d0402e4c-4266-4682-9ced-351d5ebdb79d" />

<img width="200"  alt="Simulator Screen Recording - iPhone 17 - 2026-07-08 at 17 42 55" src="https://github.com/user-attachments/assets/b28cfc3c-0ee2-4c01-b9fa-709550b1e231" />


