### PR TITLE
음료 팝업, 설정, 커리어 팝업 시 게임 일시정지 로직를 추가합니다.

### DIFF
--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/MainView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/MainView.swift
@@ -172,6 +172,9 @@ private extension MainView {
             .background(Color.white300StatusBar)
             .onTapGesture {
                 guard let careerSystem else { return }
+                if workGameSession.isInProgress {
+                    workGameSession.isPauseRequested = true
+                }
                 PopupManager.shared.show(onBackgroundTap: { PopupManager.shared.dismiss() }) {
                     CareerPopupView(careerSystem: careerSystem, user: user) {
                         PopupManager.shared.dismiss()

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/MainView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/MainView.swift
@@ -182,6 +182,9 @@ private extension MainView {
             HStack {
                 SmallButton(type: .setting) {
                     SoundService.shared.trigger(.click)
+                    if workGameSession.isInProgress {
+                        workGameSession.isPauseRequested = true
+                    }
                     PopupManager.shared.show(onBackgroundTap: { PopupManager.shared.dismiss() }) {
                         FeedbackSettingView(onClose: { PopupManager.shared.dismiss() })
                     }

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Work/Game/DodgeGameView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Work/Game/DodgeGameView.swift
@@ -269,8 +269,7 @@ private extension DodgeGameView {
                 game.user.record.record(type == .coffee ? .coffeeUse : .energyDrinkUse)
             }
         } else {
-            game.pauseGame()
-            isGamePaused = true
+            closePause = true
             let flowID = AnalyticsService.shared.makeAdRewardFlowID()
             drinkAdRewardFlowID = flowID
             let rewardType: AdRewardType = type == .coffee ? .coffee : .energyDrink
@@ -296,8 +295,7 @@ private extension DodgeGameView {
                                 )
                                 drinkAdRewardFlowID = nil
                             }
-                            game.resumeGame()
-                            isGamePaused = false
+                            closePause = false
                         },
                         adAction: {
                             SoundService.shared.trigger(.click)
@@ -342,7 +340,6 @@ private extension DodgeGameView {
                 rewardAmount: 1
             )
         }
-        game.resumeGame()
-        isGamePaused = false
+        closePause = false
     }
 }

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Work/Game/LanguageGameView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Work/Game/LanguageGameView.swift
@@ -271,7 +271,7 @@ private extension LanguageGameView {
                 game.user.record.record(type == .coffee ? .coffeeUse : .energyDrinkUse)
             }
         } else {
-            game.pauseGame()
+            closePause = true
             let flowID = AnalyticsService.shared.makeAdRewardFlowID()
             drinkAdRewardFlowID = flowID
             let rewardType: AdRewardType = type == .coffee ? .coffee : .energyDrink
@@ -297,7 +297,7 @@ private extension LanguageGameView {
                                 )
                                 drinkAdRewardFlowID = nil
                             }
-                            game.resumeGame()
+                            closePause = false
                         },
                         adAction: {
                             SoundService.shared.trigger(.click)
@@ -342,6 +342,6 @@ private extension LanguageGameView {
                 rewardAmount: 1
             )
         }
-        game.resumeGame()
+        closePause = false
     }
 }

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Work/Game/StackGameScene.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Work/Game/StackGameScene.swift
@@ -141,6 +141,10 @@ final class StackGameScene: SKScene {
         currentBlockView?.removeAllActions()
         currentBlockView?.removeFromParent()
         currentBlockView = nil
+        self.removeAllActions()
+        self.enumerateChildNodes(withName: "//*") { node, _ in
+            node.removeAllActions()
+        }
     }
 
     /// 게임 Scene 재개

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Work/Game/StackGameView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Work/Game/StackGameView.swift
@@ -192,7 +192,7 @@ private extension StackGameView {
                 stackGame.user.record.record(type == .coffee ? .coffeeUse : .energyDrinkUse)
             }
         } else {
-            scene.pauseGame()
+            closePause = true
             let flowID = AnalyticsService.shared.makeAdRewardFlowID()
             drinkAdRewardFlowID = flowID
             let rewardType: AdRewardType = type == .coffee ? .coffee : .energyDrink
@@ -218,7 +218,7 @@ private extension StackGameView {
                                 )
                                 drinkAdRewardFlowID = nil
                             }
-                            scene.resumeGame()
+                            closePause = false
                         },
                         adAction: {
                             SoundService.shared.trigger(.click)
@@ -263,6 +263,6 @@ private extension StackGameView {
                 rewardAmount: 1
             )
         }
-        scene.resumeGame()
+        closePause = false
     }
 }

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Work/Game/TapGameView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Work/Game/TapGameView.swift
@@ -194,7 +194,7 @@ private extension TapGameView {
                 tapGame.user.record.record(type == .coffee ? .coffeeUse : .energyDrinkUse)
             }
         } else {
-            tapGame.pauseGame()
+            closePause = true
             let flowID = AnalyticsService.shared.makeAdRewardFlowID()
             drinkAdRewardFlowID = flowID
             let rewardType: AdRewardType = type == .coffee ? .coffee : .energyDrink
@@ -220,7 +220,7 @@ private extension TapGameView {
                                 )
                                 drinkAdRewardFlowID = nil
                             }
-                            tapGame.resumeGame()
+                            closePause = false
                         },
                         adAction: {
                             SoundService.shared.trigger(.click)
@@ -265,6 +265,6 @@ private extension TapGameView {
                 rewardAmount: 1
             )
         }
-        tapGame.resumeGame()
+        closePause = false
     }
 }


### PR DESCRIPTION
## 연관된 이슈

- [KAN-212](https://devvup.atlassian.net/browse/KAN-212)

## 작업 내용 및 고민 내용

### 1. 음료 팝업 시 GamePauseWrapper 통해 일시정지

- 기존에는 GamePauseWrapper를 통해서가 아닌 `game.pauseGame()`을 직접 호출하고,
팝업 닫을 때 `game.resumeGame()`을 직접 호출하고 있었습니다.
- `GamePauseWrapper`를 통하지 않는 직접 호출이라 오버레이가 뜨지 않고 게임 로직만 멈추는 상태였습니다.
- `game.pauseGame()` / `game.resumeGame()` 직접 호출을 제거하고,
`closePause = true` / `false`로 `GamePauseWrapper`를 통해 pause/resume이 이루어지도록 수정했습니다.

---

### 2. 데이터쌓기 일시정지 시 블록 노드 액션 제거

- 기존 동작(문제상황)
  - 블록이 성공/실패로 착지하면 바로 다음 블록을 생성하지 않고, 0.3초 딜레이 후에 spawnBlock()을 호출하도록 예약해둡니다.
  - 문제는 이 딜레이가 예약된 직후에 일시정지가 되면, 딜레이 타이머는 멈추지 않고 계속 흘러서 0.3초 후에 spawnBlock()이 호출됩니다.
  - 그런데 resume할 때도 currentBlockView == nil이면 spawnBlock()을 호출하기 때문에, 블록이 2개 생기는 문제가 있었습니다.
- 해결
  - `pauseGame()`에서 씬 하위 모든 노드의 액션을 제거하여 resume 시 블록이 2개 생기는 현상을 수정했습니다.

---

### 3. 환경설정 버튼 및 StatusBar 클릭 시 GamePauseWrapper 통해 일시정지

- 게임 중 환경설정 버튼 및 StatusBar를 탭하면 팝업만 뜨고 게임이 멈추지 않는 상태였습니다.
- 게임 중일 때(`isInProgress`) `workGameSession.isPauseRequested = true`를 세팅해 `GamePauseWrapper`가 트리거되도록 수정했습니다.

---

## 확인해주세요

https://github.com/user-attachments/assets/ac912f23-9155-4206-9885-4a552a2b84d2

- 게임 중 `GamePauseWrapper` 오버레이가 떠야하는 상황에 뜨지 않는 곳이 있는지 확인 부탁드립니다.
- 데이터쌓기 게임 일시정지 후 재개 시 블록이 1개만 생성되는지 확인 부탁드립니다.