### PR TITLE
스킬 최대 레벨 도달 시 ItemButton에 MAX를 표시합니다.

### DIFF
--- a/DUDesignSystem/Sources/DUDesignSystem/Components/Buttons/ItemButton.swift
+++ b/DUDesignSystem/Sources/DUDesignSystem/Components/Buttons/ItemButton.swift
@@ -15,7 +15,7 @@ public struct ItemButton: View {
     }
 
     public enum ItemButtonType {
-        case singleLine(text: String, icon: DUIconName)
+        case singleLine(text: String, icon: DUIconName?)
         case twoLine(firstText: String, firstIcon: DUIconName, secondText: String, secondIcon: DUIconName)
     }
 
@@ -55,7 +55,11 @@ public struct ItemButton: View {
     private var label: some View {
         switch type {
         case .singleLine(let text, let icon):
-            ItemLabel(text: text, icon: icon, iconSize: .size16, font: .caption, color: .white300)
+            if let icon {
+                ItemLabel(text: text, icon: icon, iconSize: .size16, font: .caption, color: .white300)
+            } else {
+                ItemLabel(text: text, font: .caption, color: .white300)
+            }
         case .twoLine(let firstText, let firstIcon, let secondText, let secondIcon):
             VStack(spacing: TokenSpacing.xs) {
                 ItemLabel(text: firstText, icon: firstIcon, iconSize: .size16, font: .caption, color: .white300)

--- a/SoloDeveloperTraining/DUDesignSystemExample/Component/ComponentItemButtonView.swift
+++ b/SoloDeveloperTraining/DUDesignSystemExample/Component/ComponentItemButtonView.swift
@@ -13,6 +13,7 @@ struct ComponentItemButtonView: View {
     @State private var selectedState: ItemButton.ItemButtonState = .default
     @State private var isTwoLine: Bool = false
     @State private var isPressed: Bool = false
+    @State private var isNoIcon: Bool = false
 
     private var stateLabel: String {
         "isPressed: \(isPressed)"
@@ -21,7 +22,7 @@ struct ComponentItemButtonView: View {
     private var buttonType: ItemButton.ItemButtonType {
         isTwoLine
             ? .twoLine(firstText: text, firstIcon: .coinBag, secondText: secondText, secondIcon: .coinBag)
-            : .singleLine(text: text, icon: .coinBag)
+            : .singleLine(text: text, icon: isNoIcon ? nil : .coinBag)
     }
 
     var body: some View {
@@ -48,6 +49,9 @@ struct ComponentItemButtonView: View {
             List {
                 Section("타입") {
                     Toggle("두 줄", isOn: $isTwoLine)
+                    if !isTwoLine {
+                        Toggle("아이콘 없음", isOn: $isNoIcon)
+                    }
                 }
 
                 Section("텍스트") {

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/DisplayStateExtensions.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/DisplayStateExtensions.swift
@@ -11,7 +11,7 @@ extension ItemState {
         case .available:    return .default
         case .insufficient: return .disabled
         case .locked:       return .locked
-        case .reachedMax:   return .locked
+        case .reachedMax:   return .disabled
         }
     }
 

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/SkillView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/SkillView.swift
@@ -62,7 +62,9 @@ struct SkillView: View {
                             let total = skillState.totalGainGold
                             return "액션당 +\(Int(increase).formatted) / 현재 \(Int(total).formatted)"
                         }(),
-                        buttonType: skillState.skill.upgradeCost.itemButtonType,
+                        buttonType: skillState.itemState == .reachedMax
+                            ? .singleLine(text: "MAX", icon: nil)
+                            : skillState.skill.upgradeCost.itemButtonType,
                         buttonState: skillState.itemState.itemButtonState,
                         action: {
                             SoundService.shared.trigger(.click)


### PR DESCRIPTION
## 연관된 이슈

- [KAN-200](https://devvup.atlassian.net/browse/KAN-200)
  - [KAN-249](https://devvup.atlassian.net/browse/KAN-249)

## 작업 내용 및 고민 내용

### 1. ItemButton `singleLine`의 icon을 Optional로 변경

- 기존 `singleLine(text: String, icon: DUIconName)`에서 icon이 필수값이라 아이콘 없는 케이스를 표현할 수 없었습니다.
- Figma에서 MAX 버튼의 `iconName: none` 속성을 그대로 반영하기 위해 새로운 state를 추가하지 않고 `icon: DUIconName?`으로 변경했습니다.

---

### 2. 스킬 최대 레벨(reachedMax) 시 MAX 버튼 표시

<img height="650" alt="IMG_1022" src="https://github.com/user-attachments/assets/aa2a6355-3c6b-40da-af39-766f86a97d4b" />

- 기존에는 `reachedMax` 상태를 `.locked`로 매핑해 자물쇠 아이콘이 표시됐습니다.
- `DisplayStateExtensions`에서 `.reachedMax → .disabled`로 변경했습니다.
- `SkillView`에서 `itemState == .reachedMax`일 때 `buttonType`을 `.singleLine(text: "MAX", icon: nil)`로 교체해 MAX 텍스트가 표시되도록 했습니다.

---

### 3. DUDesignSystemExample 앱 반영

- `ComponentItemButtonView`에 "아이콘 없음" 토글을 추가해 `icon: nil` 케이스를 Example 앱에서도 확인할 수 있도록 했습니다.
