### PR TITLE
보상 팝업에 그라데이션을 추가합니다.

### DIFF
--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/UpdateRewardPopupView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/UpdateRewardPopupView.swift
@@ -17,21 +17,31 @@ struct UpdateRewardPopupView: View {
         VStack(spacing: TokenSpacing.xxl) {
             VStack(spacing: TokenSpacing.lg) {
                 ItemLabel(text: "업데이트 보상", font: .title2, color: .black300)
-                ScrollView {
-                    VStack(spacing: TokenSpacing.xxl) {
-                        ItemLabel(text: """
-                                  더 나은 서비스 제공을 위해\n개발자 키우기가 업데이트되었습니다.\n\n
-                                  이번 업데이트로 게임이 처음부터 새롭게 시작됩니다.
-                                  더 풍성한 콘텐츠와 함께 최고의 개발자를
-                                  키워나갈 수 있도록 준비했습니다.\n\n
-                                  함께해 주신 여정에 감사드리며,
-                                  이전 레벨에 따라 특별 보상을 드립니다.
-                                  """, font: .body, color: .black300)
-                        rewardInfoList
+                ZStack(alignment: .bottom) {
+                    ScrollView {
+                        VStack(spacing: TokenSpacing.xxl) {
+                            ItemLabel(text: """
+                                      더 나은 서비스 제공을 위해\n개발자 키우기가 업데이트되었습니다.\n\n
+                                      이번 업데이트로 게임이 처음부터 새롭게 시작됩니다.
+                                      더 풍성한 콘텐츠와 함께 최고의 개발자를
+                                      키워나갈 수 있도록 준비했습니다.\n\n
+                                      함께해 주신 여정에 감사드리며,
+                                      이전 레벨에 따라 특별 보상을 드립니다.
+                                      """, font: .body, color: .black300)
+                            rewardInfoList
+                        }
                     }
+                    .frame(height: 384)
+                    .scrollIndicators(.never)
+
+                    LinearGradient(
+                        colors: [Color.white300.opacity(0), Color.white300],
+                        startPoint: .top,
+                        endPoint: .bottom
+                    )
+                    .frame(height: 40)
+                    .allowsHitTesting(false)
                 }
-                .frame(height: 384)
-                .scrollIndicators(.never)
             }
             TextButton(
                 text: "보상 받기",

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/UpdateRewardPopupView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/UpdateRewardPopupView.swift
@@ -8,10 +8,19 @@
 import SwiftUI
 import DUDesignSystem
 
+private struct ScrollBottomKey: PreferenceKey {
+    static let defaultValue: CGFloat = 0
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = nextValue()
+    }
+}
+
 struct UpdateRewardPopupView: View {
     let userType: RewardUserType
     let rewards: [UpdateReward]
     let onClose: () -> Void
+
+    @State private var isScrolledToBottom = false
 
     var body: some View {
         VStack(spacing: TokenSpacing.xxl) {
@@ -30,17 +39,33 @@ struct UpdateRewardPopupView: View {
                                       """, font: .body, color: .black300)
                             rewardInfoList
                         }
+                        .overlay(alignment: .bottom) {
+                            GeometryReader { geo in
+                                Color.clear
+                                    .preference(
+                                        key: ScrollBottomKey.self,
+                                        value: geo.frame(in: .named("scrollArea")).maxY
+                                    )
+                            }
+                            .frame(height: 1)
+                        }
                     }
+                    .coordinateSpace(name: "scrollArea")
                     .frame(height: 384)
                     .scrollIndicators(.never)
+                    .onPreferenceChange(ScrollBottomKey.self) { maxY in
+                        isScrolledToBottom = maxY <= 384
+                    }
 
-                    LinearGradient(
-                        colors: [Color.white300.opacity(0), Color.white300],
-                        startPoint: .top,
-                        endPoint: .bottom
-                    )
-                    .frame(height: 40)
-                    .allowsHitTesting(false)
+                    if !isScrolledToBottom {
+                        LinearGradient(
+                            colors: [Color.white300.opacity(0), Color.white300],
+                            startPoint: .top,
+                            endPoint: .bottom
+                        )
+                        .frame(height: 40)
+                        .allowsHitTesting(false)
+                    }
                 }
             }
             TextButton(


### PR DESCRIPTION
## 연관된 이슈

- [KAN-228](https://devvup.atlassian.net/browse/KAN-228)

## 작업 내용

<img height="350" alt="image" src="https://github.com/user-attachments/assets/f388cc9c-a701-47ee-9aa5-fbc2771ea5f4" />

- 보상 팝업에서 스크롤이 된다는걸 인지시키기 위한 그라데이션 뷰를 추가합니다.
  - top -> bottom
  - 투명 흰색 -> 불투명 흰색
  - 높이 40 고정
  - 터치 무시
- 스크롤이 최하단에 도달하면 그라데이션 뷰를 숨깁니다.
  - `onScrollGeometryChange`는 iOS 18+ 라서 사용하지 못했고, PreferenceKey를 사용했습니다.
  (https://stackoverflow.com/questions/79370071/get-optimized-scrollview-value-ios)
  - PreferenceKey를 사용해 해당 뷰의 Y좌표를 ScrollView 좌표계 기준으로 상위 뷰에 전달합니다.
  - 전달된 Y좌표가 ScrollView 높이(384) 이하로 내려오면 콘텐츠 끝에 도달한 것으로 판단하여 그라데이션 뷰를 숨깁니다.

## 스크린샷

https://github.com/user-attachments/assets/dc646728-b837-4ab8-ac9f-3eb7e69a232c

