### PR TITLE
Tabbar를 기준으로 상하 화면의 비율을 1:1로 수정합니다.

### DIFF
--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/MainView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/MainView.swift
@@ -13,6 +13,8 @@ import DUDesignSystem
 private enum Constant {
     static let characterSceneSize = CGSize(width: 100, height: 100)
     static let spriteViewSize = CGSize(width: 200, height: 200)
+    // TabbarItem(48) + tabBar padding vertical md(16) × 2
+    static let tabBarHeight: CGFloat = 80
 }
 
 struct MainView: View {
@@ -88,10 +90,15 @@ struct MainView: View {
     }
 
     var body: some View {
-        VStack(spacing: TokenSpacing.none) {
-            gameViewport
-            tabBar
-            contentsPanel
+        GeometryReader { geo in
+            VStack(spacing: TokenSpacing.none) {
+                let contentHeight = (geo.size.height - Constant.tabBarHeight) / 2
+                gameViewport
+                    .frame(height: contentHeight)
+                tabBar
+                contentsPanel
+                    .frame(height: contentHeight)
+            }
         }
         .ignoresSafeArea(edges: [.top, .bottom])
         .background(Color.beige200)
@@ -201,13 +208,15 @@ private extension MainView {
                 }
             }
             Spacer()
+        }
+        .frame(maxHeight: .infinity)
+        .background(housingBackgroundView)
+        .overlay(alignment: .bottom) {
             // character Area
             SpriteView(scene: scene, options: [.allowsTransparency])
                 .frame(width: Constant.spriteViewSize.width, height: Constant.spriteViewSize.height)
                 .background(Color.clear)
         }
-        .background(housingBackgroundView)
-        .clipped()
     }
 
     var tabBar: some View {
@@ -220,6 +229,7 @@ private extension MainView {
         )
         .padding(.vertical, TokenSpacing.md)
         .padding(.horizontal, TokenGrid.paddingSide)
+        .background(Color.beige200)
         .background(GeometryReader { geo in
             Color.clear
                 .onAppear {


### PR DESCRIPTION
## 연관된 이슈

- [KAN-246](https://devvup.atlassian.net/jira/software/projects/KAN/boards/1/backlog?jql=assignee%20%3D%20712020%3A16b5d74f-98d7-4e47-91fe-dc4c4a0303f2&selectedIssue=KAN-246)

## 작업 내용

### 탭바 위아래 영역을 화면 기준 정확히 절반으로 분할

#### 원인

기존 `MainView`의 레이아웃이 아래 구조였습니다.

```swift
VStack {
    gameViewport   // Spacer() 포함 → greedy
    tabBar
    contentsPanel  // maxHeight 없음 → 콘텐츠 크기만큼
}
```

`gameViewport` 내부에 `Spacer()`가 있어 위 영역이 남은 공간을 모두 차지하면서 탭바가 화면 중앙보다 아래에 위치했습니다.

#### 수정

`GeometryReader`로 전체 높이를 측정하고, 탭바 높이(80pt)를 제외한 나머지를 정확히 절반씩 나눠 `gameViewport`와 `contentsPanel`에 명시적으로 지정합니다.

```swift
GeometryReader { geo in
    VStack {
        let contentHeight = (geo.size.height - Constant.tabBarHeight) / 2
        gameViewport.frame(height: contentHeight)
        tabBar
        contentsPanel.frame(height: contentHeight)
    }
}
```

탭바 높이 상수 계산:
- TabbarItem 내부 높이: 이미지(24) + caption lineHeight(16) + padding vertical xs(4) × 2 = **48**
- tabBar padding vertical md(16) × 2 = **32**
- 합계: **80**

### 캐릭터 SpriteView 레이어 분리

#### 원인

`gameViewport` 내부에서 `Spacer()`로 캐릭터를 하단에 밀어두는 구조였는데, `frame(height:)`로 높이를 제한하자 SpriteKit의 SKView가 SwiftUI 레이아웃 경계를 무시하고 탭바 아래까지 렌더링되었습니다.

#### 수정

캐릭터(`SpriteView`)를 `gameViewport`의 레이아웃 흐름에서 분리해 `.overlay(alignment: .bottom)`으로 배치합니다. 레이아웃 높이에 영향을 주지 않으면서 캐릭터 하단이 탭바 상단에 정확히 붙습니다.

```swift
VStack { StatusBar; 버튼영역 }
.frame(maxHeight: .infinity)
.background(housingBackgroundView)
.overlay(alignment: .bottom) {
    SpriteView(...)
        .frame(width: 200, height: 200)
}
```

### tabBar 배경색 추가

탭바 영역 뒤로 `gameViewport`의 배경 이미지가 비쳐 보이는 문제가 있어 `Color.beige200` 배경을 추가했습니다.

### 스크린샷
| 수정전 | 수정후|
|---|---|
|<img width="300" alt="Simulator Screenshot - 13미니이 - 2026-07-09 at 20 46 08" src="https://github.com/user-attachments/assets/40cab289-9980-4e97-a390-cebf4fb192b7" />|<img width="300" alt="Simulator Screenshot - 13미니이 - 2026-07-09 at 21 25 26" src="https://github.com/user-attachments/assets/5b55a70b-4ed2-42a8-ae67-e982dc3e275d" />|

## 확인해주세요

- 탭바가 화면 정중앙에 위치하는지 확인 (다양한 기기 사이즈에서)
- 캐릭터 하단이 탭바 상단에 맞닿고 잘리지 않는지 확인
- 탭바 뒤로 배경 이미지가 비치지 않는지 확인
