### PR TITLE
CareerPopupView 그라데이션 및 스크롤 로직 추가

### DIFF
--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/CareerPopupView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/CareerPopupView.swift
@@ -6,13 +6,22 @@
 //
 
 import SwiftUI
-
 import DUDesignSystem
+
+private struct ScrollBottomKey: PreferenceKey {
+    static let defaultValue: CGFloat = 0
+
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = nextValue()
+    }
+}
 
 struct CareerPopupView: View {
     let careerSystem: CareerSystem
     let user: User
     let onClose: () -> Void
+
+    @State private var isScrollable = false
 
     private var currentCareer: Career { careerSystem.currentCareer }
     private var nextCareer: Career? { currentCareer.nextCareer }
@@ -54,16 +63,55 @@ struct CareerPopupView: View {
     }
 
     private var careerList: some View {
-        ScrollView {
-            VStack(spacing: TokenSpacing.md) {
-                ForEach(Career.allCases, id: \.self) { career in
-                    CareerRow(
-                        imageName: rowImageName(for: career),
-                        title: career.rawValue,
-                        description: career.description,
-                        state: rowState(for: career)
-                    )
+        ZStack(alignment: .bottom) {
+            ScrollViewReader { proxy in
+                ScrollView {
+                    VStack(spacing: TokenSpacing.md) {
+                        ForEach(Career.allCases, id: \.self) { career in
+                            CareerRow(
+                                imageName: rowImageName(for: career),
+                                title: career.rawValue,
+                                description: career.description,
+                                state: rowState(for: career)
+                            )
+                            .id(career)
+                        }
+                    }
+                    .overlay(alignment: .bottom) {
+                        GeometryReader { geo in
+                            Color.clear
+                                .preference(
+                                    key: ScrollBottomKey.self,
+                                    value: geo.frame(in: .named("careerScroll")).maxY
+                                )
+                        }
+                        .frame(height: 1)
+                    }
                 }
+                .coordinateSpace(name: "careerScroll")
+                .frame(height: 300)
+                .scrollIndicators(.never)
+                .onAppear {
+                    withAnimation(TokenAnimation.moveSmooth.animation) {
+                        proxy.scrollTo(currentCareer, anchor: .top)
+                    }
+                }
+                .onPreferenceChange(ScrollBottomKey.self) { maxY in
+                    isScrollable = maxY > 301
+                }
+            }
+
+            if isScrollable {
+                LinearGradient(
+                    colors: [
+                        Color.white300.opacity(0),
+                        Color.white300
+                    ],
+                    startPoint: .top,
+                    endPoint: .bottom
+                )
+                .frame(height: 40)
+                .allowsHitTesting(false)
             }
         }
         .scrollIndicators(.never)


### PR DESCRIPTION
## 연관된 이슈

- [KAN-207](https://devvup.atlassian.net/browse/KAN-207)

## 작업 내용 및 고민 내용
### CareerPopupView 하단 영역 그라데이션 추가
- 가로 fill, 세로 40 사이즈의 그라데이션 뷰를 Zstack을 통해 뷰 위에 덮도록 구현했습니다.
- 스크롤 바닥 영역에 오면, 그라데이션이 보이지 않도록 구현했습니다.

### CareerPopupView 스크롤 로직 추가
- 해당 뷰의 onAppear 클로저에서 현재 레벨의 Row가 스크롤 영역의 최상단에 올 수 있도록 ScrollViewReader를 사용했습니다.
- Row에 id를 부여하여, 현재 커리어에 해당하는 항목을 찾는 방식으로 동작합니다.
- 모션은 애니메이션 토큰의 `moveSmooth`를 사용합니다.

## 스크린샷

https://github.com/user-attachments/assets/0e10585e-2c6f-4fef-8620-bca3ffbf300e

