### PR TITLE
데이터 쌓기 게임 중 일시정지했을 때 발생되는 버그를 수정합니다.

### DIFF
--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Work/Game/StackGameScene.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Work/Game/StackGameScene.swift
@@ -142,8 +142,10 @@ final class StackGameScene: SKScene {
         currentBlockView?.removeFromParent()
         currentBlockView = nil
         self.removeAllActions()
-        self.enumerateChildNodes(withName: "//*") { node, _ in
-            node.removeAllActions()
+        self.enumerateChildNodes(withName: "//*") { [weak self] node, _ in
+            if node !== self?.camera {
+                node.removeAllActions()
+            }
         }
     }
 

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Work/Game/StackGameScene.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Work/Game/StackGameScene.swift
@@ -154,8 +154,20 @@ final class StackGameScene: SKScene {
         stackGame.resumeGame()
         isGamePaused = false
         physicsWorld.speed = 1
+        removeOrphanedBombBlocks()
         if currentBlockView == nil {
             spawnBlock()
+        }
+    }
+
+    /// blockViews에도 없고 currentBlockView도 아닌 고아 BlockItem 노드를 제거합니다.
+    private func removeOrphanedBombBlocks() {
+        children.compactMap { $0 as? BlockItem }.forEach { node in
+            let isStacked = blockViews.contains(node)
+            let isCurrent = node === currentBlockView
+            if !isStacked && !isCurrent {
+                node.removeFromParent()
+            }
         }
     }
 }


### PR DESCRIPTION
## 연관된 이슈

- [KAN-252](https://devvup.atlassian.net/browse/KAN-252)

## 작업 내용 및 고민 내용

### 1. 카메라가 움직이지 않는 문제

#### 문제

<img height="650" alt="IMG_1031" src="https://github.com/user-attachments/assets/2874de4f-48bf-41d5-bc5e-276c40bf2516" />

블럭이 쌓이는 순간 게임이 일시정지(gamePauseWrapper)되면,  
씬의 모든 자식 노드 액션을 제거하는 로직(`node.removeAllActions()`)이  
카메라의 이동 액션까지 제거하여 발생하는 문제였습니다.

#### 해결
`node !== self?.camera` 조건을 추가하여 카메라 노드는 액션 제거 대상에서 제외했습니다.

---

### 2. 폭탄 블럭이 제거되지 않는 문제

#### 문제
폭탄 블럭이 착지하면 0.8초 딜레이 후 제거되도록 해당 블록 노드에 액션을 예약합니다.  
그런데 딜레이 도중 일시정지되면 블록 노드의 액션도 제거되어 폭탄 블럭이 씬에 그대로 남는 문제였습니다.

#### 해결
`resumeGame()` 시점에 씬의 자식 노드 중 스택에 쌓인 블럭도 아니고,  
낙하 중인 현재 블럭도 아닌 고아 블럭을 찾아 즉시 제거했습니다.

## 확인해주세요
데이터 쌓기 게임을 하면서 일시정지 상황을 의도적으로 많이 만들어서 테스트 부탁드립니다.