### PR TITLE
MissionCard 레이아웃이 깨지는 이슈와 스크롤 동작 문제를 해결합니다.

### DIFF
--- a/DUDesignSystem/Sources/DUDesignSystem/Components/Cards/MissionCard.swift
+++ b/DUDesignSystem/Sources/DUDesignSystem/Components/Cards/MissionCard.swift
@@ -57,7 +57,7 @@ public struct MissionCard: View {
                 ItemLabel(text: title, font: .subheadline, color: .black300)
                     .frame(maxWidth: .infinity, alignment: .leading)
 
-                HStack(spacing: TokenSpacing.sm) {
+                VStack(alignment: .leading, spacing: TokenSpacing.none) {
                     if let gold = goldRewardText {
                         ItemLabel(text: gold, icon: .coinBag, iconSize: .size16, font: .caption, color: .black300)
                     }
@@ -65,7 +65,12 @@ public struct MissionCard: View {
                         ItemLabel(text: diamond, icon: .diamond, iconSize: .size16, font: .caption, color: .black300)
                     }
                 }
-                .frame(maxWidth: .infinity, alignment: .leading)
+                .frame(
+                    maxWidth: .infinity,
+                    minHeight: 32,
+                    maxHeight: 32,
+                    alignment: .topLeading
+                )
             }
 
             Image(trophy.rawValue, bundle: .module)

--- a/DUDesignSystem/Sources/DUDesignSystem/Components/Cards/MissionCard.swift
+++ b/DUDesignSystem/Sources/DUDesignSystem/Components/Cards/MissionCard.swift
@@ -82,7 +82,7 @@ public struct MissionCard: View {
             ItemLabel(text: condition, font: .label, color: .black300)
                 .multilineTextAlignment(.center)
                 .frame(maxWidth: .infinity)
-                .frame(height: 32)
+                .frame(height: 36)
 
             stateBar
         }


### PR DESCRIPTION
## 연관된 이슈

- [KAN-248](https://devvup.atlassian.net/browse/KAN-248)
- [KAN-188](https://devvup.atlassian.net/browse/KAN-188)

## 작업 내용 및 고민 내용

### 미션 카드 레이아웃 변경
- 보상 (골드, 다이아) ItemLabel이 가로 정렬에서, 세로 정렬로 변경되었습니다.
- 보상 레이블 영역의 높이가 16 hug > 32 fixed로 변경되었습니다.
- 따라서, 카드 간의 높이가 달라서 스크롤시 버벅이던 문제도 같이 해결되었습니다.

### 미션 달성 조건 ItemLabel 영역 높이 부족 문제 해결
- 텍스트가 길어서 2줄로 넘어갈 경우, 줄 간격이 반영되는데, 기존 ItemLabel의 높이는 32로 줄 간격을 반영하지 않고 좁게 잡고 있어 텍스트가 2줄로 표시되지 못하고 말줄임표로 표시되는 문제가 있었습니다.
-  ItemLabel 높이를 36으로 변경(32+ 위아래 2씩)하여 해결했습니다.
## 스크린샷
<img width="295" height="640" alt="Simulator Screen Recording - iPhone 17 - 2026-07-10 at 18 20 50" src="https://github.com/user-attachments/assets/16a829bf-650b-4136-8a96-e66491950825" />


