### PR TITLE
신규 햅틱 적용 및 누락 햅틱을 적용합니다.

### DIFF
--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/FeedbackSystem/HapticType.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/FeedbackSystem/HapticType.swift
@@ -8,36 +8,26 @@
 import UIKit
 
 enum HapticType {
-    // Impact
-    /// 가볍고 작게 1번
-    case light
-    /// 중간 1번
+    /// 중간 세기 1번 - 설정 켤 때
     case medium
-    /// 둔탁하게 1번
-    case heavy
-    // Notification
-    /// 빠르게 2번, 점점 세기 강해짐
+    /// 빠르게 2번, 점점 강해짐 - 성공/보상
     case success
-    /// 빠르게 4번
-    case warning
-    /// 빠르게 2번, 점점 세기 약해짐
+    /// 빠르게 4번 - 레벨업
+    case levelUp
+    /// 빠르게 2번, 점점 약해짐 - 실패/오답/충돌
     case error
 
-    // 모든 타입을 실제 피드백 발생으로 매핑
     func trigger() {
         switch self {
-        // MARK: - Impact
-        case .light, .medium, .heavy:
-            let generator = UIImpactFeedbackGenerator(style: style)
+        case .medium:
+            let generator = UIImpactFeedbackGenerator(style: .medium)
             generator.prepare()
             generator.impactOccurred()
-
-        // MARK: - Notification
         case .success:
             let generator = UINotificationFeedbackGenerator()
             generator.prepare()
             generator.notificationOccurred(.success)
-        case .warning:
+        case .levelUp:
             let generator = UINotificationFeedbackGenerator()
             generator.prepare()
             generator.notificationOccurred(.warning)
@@ -45,16 +35,6 @@ enum HapticType {
             let generator = UINotificationFeedbackGenerator()
             generator.prepare()
             generator.notificationOccurred(.error)
-        }
-    }
-
-    /// Impact 스타일 매핑
-    private var style: UIImpactFeedbackGenerator.FeedbackStyle {
-        switch self {
-        case .light: return .light
-        case .medium: return .medium
-        case .heavy: return .heavy
-        default: return .medium
         }
     }
 }

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/FeedbackSettingView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/FeedbackSettingView.swift
@@ -57,7 +57,10 @@ struct FeedbackSettingView: View {
                     settingRow(
                         type: .haptic,
                         isOn: haptic.isEnabled,
-                        setOn: { haptic.isEnabled = $0 }
+                        setOn: {
+                            haptic.isEnabled = $0
+                            haptic.trigger(.medium)
+                        }
                     )
                 }
 

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/LevelUpEffectView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/LevelUpEffectView.swift
@@ -120,6 +120,7 @@ private extension LevelUpEffectView {
 private extension LevelUpEffectView {
     func startAnimation() {
         isInProgress = true
+        HapticService.shared.trigger(.levelUp)
         guard phase == .start else { return }
 
         showTitleBox = false

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/MainView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/MainView.swift
@@ -491,6 +491,7 @@ private extension MainView {
         exitBonusAdRewardFlowID = nil
 
         if result.success {
+            HapticService.shared.trigger(.success)
             AnalyticsService.shared.logAdWatchCompleted(
                 adRewardFlowID: flowID,
                 rewardType: .gold,
@@ -628,6 +629,7 @@ private extension MainView {
         offlineRewardAdFlowID = nil
 
         if result.success {
+            HapticService.shared.trigger(.success)
             AnalyticsService.shared.logAdWatchCompleted(
                 adRewardFlowID: flowID,
                 rewardType: .gold,

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/ShopView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/ShopView.swift
@@ -266,6 +266,7 @@ private extension ShopView {
             rewardAmount: 0,
             adWatchDurationSec: result.watchDurationSec
         )
+        HapticService.shared.trigger(.success)
         adBonusAppliedTypes.insert(typeKey)
         UserDefaults.standard.set(Array(adBonusAppliedTypes), forKey: Constant.UserDefaultsKey.equipmentAdBonus)
         AnalyticsService.shared.logAdRewardClaimed(

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Work/Game/QuizGameView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/Work/Game/QuizGameView.swift
@@ -260,6 +260,7 @@ private extension QuizGameView {
                 adWatchDurationSec: result.watchDurationSec
             )
             quizGame.completeGame(multiplier: 2.0)
+            HapticService.shared.trigger(.success)
             PopupManager.shared.show { rewardPopupOverlay }
             AnalyticsService.shared.logAdRewardClaimed(
                 adRewardFlowID: flowID,


### PR DESCRIPTION
## 연관된 이슈

- [KAN-183](https://devvup.atlassian.net/jira/software/projects/KAN/boards/1/backlog?jql=assignee%20%3D%20712020%3A16b5d74f-98d7-4e47-91fe-dc4c4a0303f2&selectedIssue=KAN-183)

## 작업 내용

### HapticType 정리

사용하지 않는 타입을 제거하고, 레벨업 전용 타입을 추가했습니다.

**제거된 타입:** `.light`, `.heavy`, `.warning`

**추가된 타입:** `.levelUp` — `UINotificationFeedbackGenerator(.warning)` 기반으로 빠르게 4번 울리는 진동

```swift
enum HapticType {
    case medium   // 설정 켤 때
    case success  // 성공/보상
    case levelUp  // 레벨업
    case error    // 실패/오답/충돌
}
```

### 누락된 햅틱 추가

스펙에 정의된 햅틱 중 미구현 항목들을 추가했습니다.

| 위치 | 햅틱 |
|------|------|
| 오프라인 보상 광고 시청 완료 (`MainView`) | `.success` |
| 게임 종료 보너스 광고 시청 완료 (`MainView`) | `.success` |
| 장비 강화 확률 UP 광고 시청 완료 (`ShopView`) | `.success` |
| 퀴즈 보상 광고 시청 완료 (`QuizGameView`) | `.success` |
| 레벨업 이펙트 시작 (`LevelUpEffectView`) | `.levelUp` |

### 햅틱 토글 버그 수정

`FeedbackSettingView`에서 햅틱 on/off 토글 시 `isEnabled`를 직접 변경하고 있어 실제로 `toggle()` 메서드가 호출되지 않았습니다. `toggle()`이 호출될 때 `.medium` 햅틱으로 켜짐을 알리는 피드백이 동작하지 않는 버그였습니다.

```swift
// before
haptic.isEnabled = $0

// after
haptic.toggle()
```