### PR TITLE
커리어 팝업에 환생 버튼을 추가합니다.

### DIFF
--- a/DUDesignSystem/Sources/DUDesignSystem/Components/Buttons/TextButton.swift
+++ b/DUDesignSystem/Sources/DUDesignSystem/Components/Buttons/TextButton.swift
@@ -18,6 +18,7 @@ public struct TextButton: View {
     public enum TextButtonSize {
         case large
         case medium
+        case small
     }
 
     public enum TextButtonState {
@@ -77,16 +78,18 @@ public struct TextButton: View {
 
     public var body: some View {
         ZStack(alignment: .topTrailing) {
-            ItemLabel(text: text, font: size == .large ? .headline : .subheadline, color: labelColor)
-                .opacity(state == .locked ? TokenOpacity.opacity40 : TokenOpacity.opacity100)
-                .overlay(
-                    Group {
-                        if state == .locked {
-                            DUIcon(.lock, size: .size20)
-                        }
+            ItemLabel(text: text,
+                      font: size == .large ? .headline : size == .medium ? .subheadline : .caption,
+                      color: labelColor)
+            .opacity(state == .locked ? TokenOpacity.opacity40 : TokenOpacity.opacity100)
+            .overlay(
+                Group {
+                    if state == .locked {
+                        DUIcon(.lock, size: .size20)
                     }
-                )
-            .frame(maxWidth: size == .large ? .infinity : 200)
+                }
+            )
+            .frame(maxWidth: size == .large ? .infinity : size == .medium ? 200 : 84)
             .padding(.vertical, TokenSpacing.mm)
             .background(backgroundColor)
             .clipShape(RoundedRectangle(cornerRadius: TokenRadius.sm))

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/CareerPopupView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/CareerPopupView.swift
@@ -20,6 +20,7 @@ struct CareerPopupView: View {
     let careerSystem: CareerSystem
     let user: User
     let onClose: () -> Void
+    let onRebirth: () -> Void
 
     @State private var isScrollable = false
 
@@ -76,6 +77,24 @@ struct CareerPopupView: View {
                             )
                             .id(career)
                         }
+                        if canShowRebirthRow {
+                            HStack(alignment: .center, spacing: TokenSpacing.sm) {
+                                CareerRow(
+                                    imageName: "profileNewUser",
+                                    title: "환생",
+                                    description: "다시 시작해볼까?",
+                                    state: .current
+                                )
+                                TextButton(
+                                    text: "환생하기",
+                                    type: .priority,
+                                    size: .small,
+                                    action: {
+                                    SoundService.shared.trigger(.click)
+                                    onRebirth()
+                                })
+                            }
+                        }
                     }
                     .overlay(alignment: .bottom) {
                         GeometryReader { geo in
@@ -122,8 +141,13 @@ struct CareerPopupView: View {
         let index = Career.allCases.firstIndex(of: career) ?? 0
         let current = Career.allCases.firstIndex(of: currentCareer) ?? 0
         if index < current { return .achieved }
-        if index == current { return .current }
+        if index == current && !canShowRebirthRow { return .current }
+        if index == current && canShowRebirthRow { return .achieved }
         return .upcoming
+    }
+
+    private var canShowRebirthRow: Bool {
+        user.record.scenarioProgress.isComplete(.worldClassDeveloper)
     }
 
     private func rowImageName(for career: Career) -> String {

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/MainView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/MainView.swift
@@ -191,47 +191,7 @@ private extension MainView {
                         },
                         onRebirth: {
                             PopupManager.shared.dismiss()
-                            PopupManager.shared.show(onBackgroundTap: { PopupManager.shared.dismiss() }) {
-                                NoticePopup(
-                                    type: .confirm(
-                                        cancelText: "그냥 살기",
-                                        confirmText: "환생하기",
-                                        cancelAction: {
-                                            SoundService.shared.trigger(.click)
-                                            PopupManager.shared.dismiss()
-                                        },
-                                        confirmAction: {
-                                            SoundService.shared.trigger(.click)
-                                            PopupManager.shared.dismiss()
-                                            let evt01 = user.record.choiceHistory[.juniorDeveloper] ?? .optionA
-                                            let evt02 = user.record.choiceHistory[.nightOwlDeveloper] ?? .optionA
-                                            let evt03 = user.record.choiceHistory[.famousDeveloper] ?? .optionA
-                                            let evt04 = user.record.choiceHistory[.worldClassDeveloper] ?? .optionA
-                                            let ending = scenarioRepository.calculateEnding(
-                                                evt01: evt01,
-                                                evt02: evt02,
-                                                evt03: evt03,
-                                                evt04: evt04
-                                            )
-                                            user.resetForRebirth(ending: ending)
-                                            let pages = scenarioRepository.fetchRebirthScenarioPages()
-                                            let rebirthScenario = Scenario(
-                                                id: "rebirth",
-                                                career: .unemployed,
-                                                scenarioType: .rebirth,
-                                                pages: pages
-                                            )
-                                            let manager = ScenarioManager(record: user.record)
-                                            manager.startScenario(rebirthScenario)
-                                            scenarioManager = manager
-                                            showScenarioView = true
-                                            SoundService.shared.playBGM(.rebirth)
-                                        }
-                                    ),
-                                    title: "환생하기",
-                                    text: "전생의 기억은 모두 잃고 새로 태어나게됩니다.\n환생하시겠습니까?"
-                                )
-                            }
+                            showRebirthConfirmPopup()
                         }
                     )
                 }
@@ -389,6 +349,44 @@ private extension MainView {
                 }
             }
         }
+    }
+
+    func showRebirthConfirmPopup() {
+        PopupManager.shared.show(onBackgroundTap: { PopupManager.shared.dismiss() }) {
+            NoticePopup(
+                type: .confirm(
+                    cancelText: "그냥 살기",
+                    confirmText: "환생하기",
+                    cancelAction: {
+                        SoundService.shared.trigger(.click)
+                        PopupManager.shared.dismiss()
+                    },
+                    confirmAction: {
+                        SoundService.shared.trigger(.click)
+                        PopupManager.shared.dismiss()
+                        handleRebirth()
+                    }
+                ),
+                title: "환생하기",
+                text: "전생의 기억은 모두 잃고 새로 태어나게됩니다.\n환생하시겠습니까?"
+            )
+        }
+    }
+
+    func handleRebirth() {
+        let evt01 = user.record.choiceHistory[.juniorDeveloper] ?? .optionA
+        let evt02 = user.record.choiceHistory[.nightOwlDeveloper] ?? .optionA
+        let evt03 = user.record.choiceHistory[.famousDeveloper] ?? .optionA
+        let evt04 = user.record.choiceHistory[.worldClassDeveloper] ?? .optionA
+        let ending = scenarioRepository.calculateEnding(evt01: evt01, evt02: evt02, evt03: evt03, evt04: evt04)
+        user.resetForRebirth(ending: ending)
+        let pages = scenarioRepository.fetchRebirthScenarioPages()
+        let rebirthScenario = Scenario(id: "rebirth", career: .unemployed, scenarioType: .rebirth, pages: pages)
+        let manager = ScenarioManager(record: user.record)
+        manager.startScenario(rebirthScenario)
+        scenarioManager = manager
+        showScenarioView = true
+        SoundService.shared.playBGM(.rebirth)
     }
 
     @MainActor

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/MainView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/MainView.swift
@@ -183,9 +183,57 @@ private extension MainView {
                     workGameSession.isPauseRequested = true
                 }
                 PopupManager.shared.show(onBackgroundTap: { PopupManager.shared.dismiss() }) {
-                    CareerPopupView(careerSystem: careerSystem, user: user) {
-                        PopupManager.shared.dismiss()
-                    }
+                    CareerPopupView(
+                        careerSystem: careerSystem,
+                        user: user,
+                        onClose: {
+                            PopupManager.shared.dismiss()
+                        },
+                        onRebirth: {
+                            PopupManager.shared.dismiss()
+                            PopupManager.shared.show(onBackgroundTap: { PopupManager.shared.dismiss() }) {
+                                NoticePopup(
+                                    type: .confirm(
+                                        cancelText: "그냥 살기",
+                                        confirmText: "환생하기",
+                                        cancelAction: {
+                                            SoundService.shared.trigger(.click)
+                                            PopupManager.shared.dismiss()
+                                        },
+                                        confirmAction: {
+                                            SoundService.shared.trigger(.click)
+                                            PopupManager.shared.dismiss()
+                                            let evt01 = user.record.choiceHistory[.juniorDeveloper] ?? .optionA
+                                            let evt02 = user.record.choiceHistory[.nightOwlDeveloper] ?? .optionA
+                                            let evt03 = user.record.choiceHistory[.famousDeveloper] ?? .optionA
+                                            let evt04 = user.record.choiceHistory[.worldClassDeveloper] ?? .optionA
+                                            let ending = scenarioRepository.calculateEnding(
+                                                evt01: evt01,
+                                                evt02: evt02,
+                                                evt03: evt03,
+                                                evt04: evt04
+                                            )
+                                            user.resetForRebirth(ending: ending)
+                                            let pages = scenarioRepository.fetchRebirthScenarioPages()
+                                            let rebirthScenario = Scenario(
+                                                id: "rebirth",
+                                                career: .unemployed,
+                                                scenarioType: .rebirth,
+                                                pages: pages
+                                            )
+                                            let manager = ScenarioManager(record: user.record)
+                                            manager.startScenario(rebirthScenario)
+                                            scenarioManager = manager
+                                            showScenarioView = true
+                                            SoundService.shared.playBGM(.rebirth)
+                                        }
+                                    ),
+                                    title: "환생하기",
+                                    text: "전생의 기억은 모두 잃고 새로 태어나게됩니다.\n환생하시겠습니까?"
+                                )
+                            }
+                        }
+                    )
                 }
             }
             // SettingButton, QuizButton Area


### PR DESCRIPTION
## 연관된 이슈

- [KAN-255](https://devvup.atlassian.net/browse/KAN-255)

## 작업 내용 및 고민 내용

### 1. TextButton에 small 사이즈 추가
- `TextButtonSize`에 `small` 케이스를 추가했습니다.

---

### 2. CareerPopupView에 환생 Row 추가
- 월드클래스 개발자 시나리오를 완료한 경우(`scenarioProgress.isComplete(.worldClassDeveloper)`) 커리어 리스트 맨 아래에 환생 Row가 추가됩니다.
- 환생 Row는 `profileNewUser` 이미지와 함께 `.current` 스타일(노란 테두리)로 표시됩니다.
- 월드클래스 개발자 Row는 이 경우 `.achieved`(완료) 상태로 렌더링됩니다.
  - StatusBar의 커리어 표시는 변경 없이 월드클래스 개발자로 유지됩니다.
  - (커리어 모델을 작업하지 않고 렌더링만 변경하게 했습니다.)
- `onRebirth: () -> Void` 클로저를 파라미터로 추가했습니다.

---

### 3. MainView에 환생 확인 팝업 및 환생 처리 추가
- 환생하기 버튼 탭 시 확인 팝업("그냥 살기" / "환생하기")을 먼저 표시합니다.
- 확인 시 `choiceHistory`로 Ending을 계산하고 `resetForRebirth`를 실행한 뒤 rebirth 시나리오를 시작합니다.

---

### 수정된 파일
| 파일 | 내용 |
|---|---|
| `TextButton.swift` | `small` 사이즈 추가 |
| `CareerPopupView.swift` | 환생 Row 및 `onRebirth` 클로저 추가 |
| `MainView.swift` | `showRebirthConfirmPopup()`, `handleRebirth()` 추가 |

---

## 확인해주세요

https://github.com/user-attachments/assets/bbb01975-b93c-476c-a794-905bf65041c3

- 월드클래스 개발자 + 최종 엔딩 시나리오 완료 후 커리어 팝업에서 환생 Row가 노출되는지 확인 부탁드립니다.
- 환생하기 버튼 탭 → 확인 팝업 → 환생 시나리오로 정상 진입하는지 확인 부탁드립니다.