### PR TITLE
오프라인 팝업, 레벨업, 시나리오 복구 오버레이 재배치 및 플래그 추가

### DIFF
--- a/DUDesignSystem/Sources/DUDesignSystem/Components/Toast.swift
+++ b/DUDesignSystem/Sources/DUDesignSystem/Components/Toast.swift
@@ -54,7 +54,7 @@ public final class ToastManager {
     private var dismissWorkItem: DispatchWorkItem?
 
     @MainActor
-    public func show(_ message: String, anchor: ToastAnchor = .default) {
+    public func show(_ message: String, anchor: ToastAnchor = .default, onShown: (() -> Void)? = nil) {
         guard let window = UIApplication.shared.connectedScenes
             .compactMap({ $0 as? UIWindowScene })
             .first(where: { $0.activationState == .foregroundActive })?
@@ -100,6 +100,8 @@ public final class ToastManager {
 
         UIView.animate(withDuration: TokenAnimation.fadeInSlow.timeInterval) {
             contentView.alpha = 1
+        } completion: { finished in
+            if finished { onShown?() }
         }
 
         let workItem = DispatchWorkItem { [weak self, weak hostingController] in

--- a/SoloDeveloperTraining/SoloDeveloperTraining.xcodeproj/project.pbxproj
+++ b/SoloDeveloperTraining/SoloDeveloperTraining.xcodeproj/project.pbxproj
@@ -103,6 +103,7 @@
 				Production/Presentation/Intro/NicknameSetupView.swift,
 				Production/Presentation/Intro/TutorialPageView.swift,
 				Production/Presentation/Intro/TutorialView.swift,
+				Production/Presentation/LevelUpEffectManager.swift,
 				Production/Presentation/LevelUpEffectView.swift,
 				Production/Presentation/MainView.swift,
 				Production/Presentation/MissionView.swift,

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/LevelUpEffectManager.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/LevelUpEffectManager.swift
@@ -1,0 +1,60 @@
+//
+//  LevelUpEffectManager.swift
+//  SoloDeveloperTraining
+//
+
+import SwiftUI
+import UIKit
+
+@MainActor
+final class LevelUpEffectManager {
+    static let shared = LevelUpEffectManager()
+    private init() {}
+
+    private var levelUpWindow: UIWindow?
+
+    func show(
+        previousCareerTitle: String,
+        currentCareerTitle: String,
+        onDismiss: @escaping () -> Void
+    ) {
+        guard let windowScene = UIApplication.shared.connectedScenes
+            .compactMap({ $0 as? UIWindowScene })
+            .first(where: { $0.activationState == .foregroundActive })
+        else { return }
+
+        dismiss()
+
+        let window = UIWindow(windowScene: windowScene)
+        window.windowLevel = .normal + 1
+        window.backgroundColor = .clear
+
+        let view = LevelUpEffectView(
+            onDismiss: { [weak self] in
+                self?.dismiss()
+                onDismiss()
+            },
+            previousCareerTitle: previousCareerTitle,
+            currentCareerTitle: currentCareerTitle
+        )
+        let hostingController = UIHostingController(rootView: view)
+        hostingController.view.backgroundColor = .clear
+        window.rootViewController = hostingController
+        window.alpha = 0
+        window.isHidden = false
+        UIView.animate(withDuration: 0.25, delay: 0, options: .curveEaseInOut) {
+            window.alpha = 1
+        }
+        levelUpWindow = window
+    }
+
+    func dismiss() {
+        let windowToHide = levelUpWindow
+        levelUpWindow = nil
+        UIView.animate(withDuration: 0.25, delay: 0, options: .curveEaseInOut) {
+            windowToHide?.alpha = 0
+        } completion: { _ in
+            windowToHide?.isHidden = true
+        }
+    }
+}

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/LevelUpEffectView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/LevelUpEffectView.swift
@@ -21,7 +21,7 @@ struct LevelUpEffectView: View {
         case start, loop
     }
 
-    @Binding var isPresented: Bool
+    var onDismiss: () -> Void
     let previousCareerTitle: String
     let currentCareerTitle: String
 
@@ -37,7 +37,7 @@ struct LevelUpEffectView: View {
                 .ignoresSafeArea()
                 .onTapGesture {
                     if !isInProgress {
-                        isPresented = false
+                        onDismiss()
                     }
                 }
 
@@ -148,9 +148,8 @@ private extension LevelUpEffectView {
 }
 
 #Preview {
-    @Previewable @State var isPresented: Bool = true
     LevelUpEffectView(
-        isPresented: $isPresented,
+        onDismiss: {},
         previousCareerTitle: "이전 개발자",
         currentCareerTitle: "이후 개발자"
     )

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/MainView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/MainView.swift
@@ -112,17 +112,6 @@ struct MainView: View {
             guard !isOfflineRewardPopupShowing else { return }
             careerSystem?.updateCareer()
         }
-        .overlay {
-            if showLevelUpEffect {
-                LevelUpEffectView(
-                    isPresented: $showLevelUpEffect,
-                    previousCareerTitle: previousCareer?.rawValue ?? "",
-                    currentCareerTitle: leveledUpCareer?.rawValue ?? ""
-                )
-                .transition(TokenTransition.overlay.effect)
-            }
-        }
-        .animation(TokenTransition.overlay.animation, value: showLevelUpEffect)
         .onChange(of: showLevelUpEffect) { _, isPresented in
             if isPresented && workGameSession.isInProgress {
                 workGameSession.isPauseRequested = true
@@ -348,6 +337,11 @@ private extension MainView {
                 showLevelUpEffect = isLevelUp
                 if isLevelUp {
                     SoundService.shared.trigger(.levelUp)
+                    LevelUpEffectManager.shared.show(
+                        previousCareerTitle: oldCareer.rawValue,
+                        currentCareerTitle: newCareer.rawValue,
+                        onDismiss: { showLevelUpEffect = false }
+                    )
                 }
             }
         }
@@ -401,7 +395,15 @@ private extension MainView {
         if let pendingCareer = user.record.scenarioProgress.levelupQueue.first {
             previousCareer = user.career
             leveledUpCareer = pendingCareer
-            showLevelUpEffect = pendingCareer != .unemployed
+            let shouldShow = pendingCareer != .unemployed
+            showLevelUpEffect = shouldShow
+            if shouldShow {
+                LevelUpEffectManager.shared.show(
+                    previousCareerTitle: user.career.rawValue,
+                    currentCareerTitle: pendingCareer.rawValue,
+                    onDismiss: { showLevelUpEffect = false }
+                )
+            }
         }
     }
 
@@ -563,7 +565,9 @@ private extension MainView {
                 rewardAmount: bonusGold,
                 adWatchDurationSec: result.watchDurationSec
             )
-            applyExitBonus()
+            applyExitBonus(onToastShown: bonusGold > 0 ? { [self] in
+                user.record.record(.earnMoney(bonusGold))
+            } : nil)
             AnalyticsService.shared.logAdRewardClaimed(
                 adRewardFlowID: flowID,
                 rewardType: .gold,
@@ -605,13 +609,15 @@ private extension MainView {
         AppPreferences.shared.hasClaimedGameResetReward = true
     }
 
-    func applyExitBonus() {
+    func applyExitBonus(onToastShown: (() -> Void)? = nil) {
         let bonusGold = max(0, workGameSession.actionGoldDelta)
         if bonusGold > 0 {
             user.wallet.addGold(bonusGold)
-            user.record.record(.earnMoney(bonusGold))
         }
-        ToastManager.shared.show(bonusGold > 0 ? "업무에서 얻은 보상 2배 획득!" : "업무 보너스를 받을 재화가 없습니다.")
+        ToastManager.shared.show(
+            bonusGold > 0 ? "업무에서 얻은 보상 2배 획득!" : "업무 보너스를 받을 재화가 없습니다.",
+            onShown: onToastShown
+        )
     }
 
     func exitWorkGame() {

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/MainView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/MainView.swift
@@ -40,6 +40,7 @@ struct MainView: View {
     @State private var offlineRewardGold: Int = 0
     @State private var offlineRewardHours: Double = 0.0
     @State private var hasCheckedOfflineReward: Bool = false
+    @State private var isOfflineRewardPopupShowing: Bool = false
     @State private var offlineRewardAdFlowID: String?
 
     // 레벨업 이펙트 관련
@@ -108,6 +109,7 @@ struct MainView: View {
         }
         .onChange(of: scenePhase, handleScenePhaseChange)
         .onChange(of: user.record.totalEarnedMoney) {
+            guard !isOfflineRewardPopupShowing else { return }
             careerSystem?.updateCareer()
         }
         .overlay {
@@ -392,7 +394,8 @@ private extension MainView {
     @MainActor
     func checkPendingLevelUp() {
         // 이미 시나리오가 떠 있거나 레벨업 이펙트가 진행 중이면 리턴
-        guard !showScenarioView && !showLevelUpEffect else { return }
+        // 오프라인 보상 팝업이 표시 중이면 팝업 처리 후 레벨업 진행
+        guard !showScenarioView && !showLevelUpEffect && !isOfflineRewardPopupShowing else { return }
 
         // 큐에 대기 중인 레벨업 커리어가 있다면 이펙트 다시 표시
         if let pendingCareer = user.record.scenarioProgress.levelupQueue.first {
@@ -620,6 +623,7 @@ private extension MainView {
     // MARK: - Offline Reward
 
     func showOfflineRewardPopup() {
+        isOfflineRewardPopupShowing = true
         trackOfflineRewardAdOfferIfNeeded()
         PopupManager.shared.show {
             NoticePopup(
@@ -690,6 +694,7 @@ private extension MainView {
         let result = await AdService.shared.showAdWithResult(.interstitial)
         if result.isOffline {
             PopupManager.shared.showNoNetworkAlert()
+            isOfflineRewardPopupShowing = false
             return
         }
         offlineRewardAdFlowID = nil
@@ -713,6 +718,8 @@ private extension MainView {
         }
         offlineRewardGold = 0
         offlineRewardHours = 0.0
+        isOfflineRewardPopupShowing = false
+        careerSystem?.updateCareer()
         checkPendingLevelUp()
         if !showLevelUpEffect {
             restoreScenarioIfNeeded()
@@ -735,6 +742,8 @@ private extension MainView {
         offlineRewardHours = 0.0
         // 다음 체크를 위해 플래그 리셋
         hasCheckedOfflineReward = false
+        isOfflineRewardPopupShowing = false
+        careerSystem?.updateCareer()
         checkPendingLevelUp()
         if !showLevelUpEffect {
             restoreScenarioIfNeeded()


### PR DESCRIPTION
## 연관된 이슈

- [#KAN-203](https://devvup.atlassian.net/jira/software/projects/KAN/boards/1/backlog?selectedIssue=KAN-203)

## 작업 내용

### 오프라인 보상 팝업 노출 순서 수정

오프라인 보상 팝업이 레벨업 이펙트 / 시나리오 화면에 가려 보이지 않던 문제를 수정했습니다.

**기존 문제:**
- 오프라인 보상 팝업이 표시되는 동안 레벨업이 감지되면, 레벨업 이펙트 → 시나리오 `fullScreenCover`가 팝업 위에 올라와 팝업이 가려짐

**원인:**
- `PopupManager`는 UIWindow의 subview로 팝업을 추가하지만, SwiftUI `fullScreenCover`는 UIKit 모달 계층으로 그 위에 표시됨
- 팝업 표시 중에도 `onChange(totalEarnedMoney)` → `updateCareer()` 및 `checkPendingLevelUp()`이 차단 없이 실행되어 레벨업/시나리오가 먼저 시작됨

**수정 내용:**
- `isOfflineRewardPopupShowing` 플래그 추가
- 팝업 표시 중 `onChange(totalEarnedMoney)` → `updateCareer()` 차단
- 팝업 표시 중 `checkPendingLevelUp()` 차단
- 팝업 종료(광고 시청 / 안받기 / 오프라인 취소) 후 `updateCareer()` → `checkPendingLevelUp()` → 시나리오 복원 순으로 진행
- `isOffline` early return 케이스에서 플래그 미해제 버그 수정

**수정 후 흐름:**
```
오프라인 보상 팝업 → 보상받기/안받기 → 레벨업 이펙트 → 시나리오 진입
```

### 업무 종료 보상 토스트 / 레벨업 이펙트 노출 순서 수정

업무 종료 후 광고 시청 시 보상 토스트와 레벨업 이펙트가 동시에 노출되던 문제를 수정했습니다.

**기존 문제:**
- 광고 시청 완료 후 보상 지급(`earnMoney`)과 토스트 표시가 동시에 발생해, `onChange` → 레벨업 이펙트가 토스트 위에 덮여 보상 안내가 가려짐

**원인:**
- `ToastManager`는 UIWindow의 subview로 추가되지만, 레벨업 이펙트는 SwiftUI `.overlay`로 UIHostingController 내부에 렌더링되어 z-order상 토스트보다 아래에 위치
- 보상 지급과 토스트 표시가 동기적으로 실행되어 레벨업 이펙트가 토스트와 동시에 등장

**수정 내용:**
- `LevelUpEffectManager` 추가: 레벨업 이펙트를 `windowLevel = .normal + 1` 별도 UIWindow에서 렌더링 → 항상 토스트 위에 표시되도록 z-order 보장
- `ToastManager.show(onShown:)` 콜백 추가: 토스트 페이드인(0.5s) 완료 후 콜백 실행
- 업무 종료 광고 보상 흐름에서 `earnMoney` 기록을 `onShown` 콜백 내로 이동 → 토스트가 완전히 노출된 뒤 레벨업 시작

**수정 후 흐름:**
```
광고 완료 → 보상 토스트 등장 (0.5s 페이드인) → 레벨업 이펙트 (토스트 위) → 시나리오 진입
```

### 스크린샷

https://github.com/user-attachments/assets/f8fd6b54-e487-46e3-86f5-6c67d94e74d7

