### PR TITLE
아이템 목록 'MAX' 상태를 표시하고, 라이팅을 수정합니다.

### DIFF
--- a/SoloDeveloperTraining/SoloDeveloperTraining/GameCore/Models/Items/Consumable.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/GameCore/Models/Items/Consumable.swift
@@ -15,7 +15,7 @@ final class Consumable: Item {
         return type.displayTitle + " (보유:\(count)개)"
     }
     var description: String {
-        return "사용시 골드 획득량 \(type.buffMultiplier)배 증가"
+        return "사용시 업무 골드 획득 x\(type.buffMultiplier)"
     }
     var cost: Cost {
         return type.cost

--- a/SoloDeveloperTraining/SoloDeveloperTraining/GameCore/Models/Items/Equipment.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/GameCore/Models/Items/Equipment.swift
@@ -19,7 +19,7 @@ final class Equipment: Item {
         }
         let nextTier = EquipmentTier(rawValue: tier.rawValue + 1) ?? .nationalTreasure
         let nextEquipment = Equipment(type: type, tier: nextTier)
-        return "강화시 초당 골드 획득량 \(goldPerSecond.formatted) -> \(nextEquipment.goldPerSecond.formatted)"
+        return "강화시 초당 +\(nextEquipment.goldPerSecond.formatted) / 현재 \(goldPerSecond.formatted)"
     }
     var cost: Cost {
         return tier.cost

--- a/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/ShopView.swift
+++ b/SoloDeveloperTraining/SoloDeveloperTraining/Production/Presentation/ShopView.swift
@@ -79,12 +79,15 @@ private extension ShopView {
         ScrollView {
             LazyVStack(spacing: TokenSpacing.md) {
                 ForEach(displayItems) { item in
+                    let itemState = ItemState(item: item)
                     ItemRow(
                         imageName: item.imageName,
                         title: item.displayTitle,
                         description: item.description,
-                        buttonType: item.cost.itemButtonType,
-                        buttonState: ItemState(item: item).itemButtonState
+                        buttonType: itemState == .reachedMax
+                            ? .singleLine(text: "MAX", icon: nil)
+                        : item.cost.itemButtonType,
+                        buttonState: itemState.itemButtonState
                     ) {
                         SoundService.shared.trigger(.click)
                         purchase(item: item)


### PR DESCRIPTION
## 연관된 이슈

- [KAN-258](https://devvup.atlassian.net/browse/KAN-258)
- [KAN-260](https://devvup.atlassian.net/browse/KAN-260)

## 작업 내용 및 고민 내용

### 아이템 항목 버튼 '최고 레벨 도달' 상태 표시
-  상점 > 아이템 항목이 최고 레벨 도달 상태(reachedMax)인 경우, 스킬과 동일하게 'disable'상태에 'MAX' 텍스트만 표시하도록 수정했습니다.

### 아이템 항목 설명 문구 수정
- 설명이 길어질 경우 2줄이 넘는 문제를 해결하기 위해 다음과 같이 라이팅 정책이 수정되었습니다.
  - 소비 아이템: '사용시 골드 획득량 2.0배 증가' > '사용시 업무 골드 획득 x2.0'
  - 장비 아이템: '강화시 초당 골드 획득량 0 -> 1.25K' > '강화시 초당 +1.25K / 현재 0'

## 스크린샷
<img width="200" alt="image" src="https://github.com/user-attachments/assets/3a485c8e-6b45-48e9-bdc1-6b59ee972843" />

